### PR TITLE
Fix config logs

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -66,8 +66,10 @@ impl IndexerConfiguration {
     pub fn from_args(args: IndexingArgs) -> Self {
         // If a config file is provided, it takes precedence for file-based fields.
         let file_config = if let Some(ref config_file) = args.config {
-            println!("Loading configuration from file: {}", config_file);
-            println!("CLI arguments for file-based fields will be ignored");
+            if args.verbosity >= 2 {
+                println!("Loading configuration from file: {}", config_file);
+                println!("CLI arguments for file-based fields will be ignored");
+            }
             match FileConfiguration::load(config_file) {
                 Ok(config) => config,
                 Err(e) => match e {


### PR DESCRIPTION
- Refactor config logs to use std:io and std:err as tracing is not activated.
- `ConfigError:NotFound` only matched when a property is not found. When config file is not found, `ConfigError:Foreign` is triggered instead.