### PR TITLE
PostreSQL backend support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
         run: SKIP_DOCKER=true ./script/init_postgresql.bash
       - name: Tests
         env:
-          DATABASE_URL: postgres://postgres:password@localhost:5432/quixote_test
+          DATABASE_URL: postgres://postgres:password@localhost:5432/quixote
         run: |
           QUIXOTE_TEST_RPC=${{ secrets.QUIXOTE_TEST_RPC }} \
           QUIXOTE_TEST_RPC_USER=${{ secrets.QUIXOTE_TEST_RPC_USER }} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,4 +91,4 @@ jobs:
           QUIXOTE_TEST_RPC=${{ secrets.QUIXOTE_TEST_RPC }} \
           QUIXOTE_TEST_RPC_USER=${{ secrets.QUIXOTE_TEST_RPC_USER }} \
           QUIXOTE_TEST_RPC_PASSWORD=${{ secrets.QUIXOTE_TEST_RPC_PASSWORD }} \
-          cargo test
+          cargo test --all-features

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,7 +73,7 @@ jobs:
         image: postgres:16
         env:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: password
           POSTGRES_DB: quixote_test
         ports:
           - 5432:5432
@@ -97,7 +97,7 @@ jobs:
         run: SKIP_DOCKER=true ./script/init_postgresql.bash
       - name: Tests
         env:
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/quixote_test
+          DATABASE_URL: postgres://postgres:password@localhost:5432/quixote_test
         run: |
           QUIXOTE_TEST_RPC=${{ secrets.QUIXOTE_TEST_RPC }} \
           QUIXOTE_TEST_RPC_USER=${{ secrets.QUIXOTE_TEST_RPC_USER }} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           components: rustfmt clippy
       - name: Build with all features
-        run: cargo check --all-features --future-incompat-report
+        run: SQLX_OFFLINE=true cargo check --all-features --future-incompat-report
 
   clippy:
     name: Clippy linter
@@ -59,18 +59,34 @@ jobs:
         with:
           components: rustfmt clippy
       - name: Linting with all features
-        run: cargo clippy --all-features --no-deps -- -D warnings
+        run: SQLX_OFFLINE=true cargo clippy --all-features --no-deps -- -D warnings
 
   # Comprehensive test with all features
   test:
     name: Test
     needs: clippy
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: quixote_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2.8.2
       - uses: dtolnay/rust-toolchain@stable
       - name: Tests
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/quixote_test
         run: |
           QUIXOTE_TEST_RPC=${{ secrets.QUIXOTE_TEST_RPC }} \
           QUIXOTE_TEST_RPC_USER=${{ secrets.QUIXOTE_TEST_RPC_USER }} \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,8 @@ name: Rust Main
 
 env:
   CARGO_TERM_COLOR: always
+  SQLX_VERSION: 0.8.6
+  SQLX_FEATURES: "postgres"
 
 # Run for every event affecting the main branch
 on:
@@ -84,6 +86,15 @@ jobs:
       - uses: actions/checkout@v6
       - uses: Swatinem/rust-cache@v2.8.2
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install SQLx-cli
+        run:
+            cargo install sqlx-cli
+            --version=${{ env.SQLX_VERSION }}
+            --features ${{ env.SQLX_FEATURES }}
+            --no-default-features
+            --locked
+      - name: Migrate database
+        run: SKIP_DOCKER=true ./script/init_postgresql.bash
       - name: Tests
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/quixote_test

--- a/.sqlx/query-05067f823b93f335e0e5ef3c953aab0f1e9925152a9dc50a1c05e4b35988a23e.json
+++ b/.sqlx/query-05067f823b93f335e0e5ef3c953aab0f1e9925152a9dc50a1c05e4b35988a23e.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT chain_id, event_hash, event_signature, event_name, first_block, last_block FROM event_descriptor",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "chain_id",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 1,
+        "name": "event_hash",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 2,
+        "name": "event_signature",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 3,
+        "name": "event_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "first_block",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 5,
+        "name": "last_block",
+        "type_info": "Numeric"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "05067f823b93f335e0e5ef3c953aab0f1e9925152a9dc50a1c05e4b35988a23e"
+}

--- a/.sqlx/query-08ac39283505d7f7e171c4fbb86c526ef7acb8d1e140f99aa93b8474cc29a788.json
+++ b/.sqlx/query-08ac39283505d7f7e171c4fbb86c526ef7acb8d1e140f99aa93b8474cc29a788.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE event_descriptor SET last_block = (\n                        SELECT MAX(last_block) FROM event_descriptor WHERE chain_id = $1 AND event_hash = ANY($2)\n                    ) WHERE chain_id = $1 AND event_hash = ANY($2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Numeric",
+        "ByteaArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "08ac39283505d7f7e171c4fbb86c526ef7acb8d1e140f99aa93b8474cc29a788"
+}

--- a/.sqlx/query-0c4d6dd0b6edea647a14a51d8e0697f908e8c9c5c6b76eb80653bf89396af9b8.json
+++ b/.sqlx/query-0c4d6dd0b6edea647a14a51d8e0697f908e8c9c5c6b76eb80653bf89396af9b8.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE event_descriptor SET first_block = $1 WHERE chain_id = $2 AND event_hash = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Numeric",
+        "Numeric",
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "0c4d6dd0b6edea647a14a51d8e0697f908e8c9c5c6b76eb80653bf89396af9b8"
+}

--- a/.sqlx/query-3b1ea7fbd407ed5d116d40564bc1b964022082c63ceb3cd7d124f274e3bc611f.json
+++ b/.sqlx/query-3b1ea7fbd407ed5d116d40564bc1b964022082c63ceb3cd7d124f274e3bc611f.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT event_name, first_block, last_block FROM event_descriptor WHERE chain_id = $1 AND event_hash = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "event_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "first_block",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 2,
+        "name": "last_block",
+        "type_info": "Numeric"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Numeric",
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "3b1ea7fbd407ed5d116d40564bc1b964022082c63ceb3cd7d124f274e3bc611f"
+}

--- a/.sqlx/query-4cf740feceecaaa2bb1d60bfbdb11f6f2e61a9d4f120eed499c0bb20476d3e6e.json
+++ b/.sqlx/query-4cf740feceecaaa2bb1d60bfbdb11f6f2e61a9d4f120eed499c0bb20476d3e6e.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT event_signature FROM event_descriptor WHERE event_hash = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "event_signature",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "4cf740feceecaaa2bb1d60bfbdb11f6f2e61a9d4f120eed499c0bb20476d3e6e"
+}

--- a/.sqlx/query-4f91e0356313ac039cae996d75d76aa7a3c1dabf7867349adaf2cc270b1dec62.json
+++ b/.sqlx/query-4f91e0356313ac039cae996d75d76aa7a3c1dabf7867349adaf2cc270b1dec62.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE event_descriptor SET last_block = $1 WHERE chain_id = $2 AND event_hash = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Numeric",
+        "Numeric",
+        "Bytea"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4f91e0356313ac039cae996d75d76aa7a3c1dabf7867349adaf2cc270b1dec62"
+}

--- a/.sqlx/query-57b479c3ad6267dc15bac5e760af30b793646d2404ee7f6b4b5a20ec7a95450f.json
+++ b/.sqlx/query-57b479c3ad6267dc15bac5e760af30b793646d2404ee7f6b4b5a20ec7a95450f.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT first_block FROM event_descriptor WHERE chain_id = $1 AND event_hash = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "first_block",
+        "type_info": "Numeric"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Numeric",
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "57b479c3ad6267dc15bac5e760af30b793646d2404ee7f6b4b5a20ec7a95450f"
+}

--- a/.sqlx/query-8ebcbc60059f25a3cec80b0356718f9500c7a7008dbdd40e7be8a33336fa58f1.json
+++ b/.sqlx/query-8ebcbc60059f25a3cec80b0356718f9500c7a7008dbdd40e7be8a33336fa58f1.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT chain_id, event_hash, event_name FROM event_descriptor",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "chain_id",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 1,
+        "name": "event_hash",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 2,
+        "name": "event_name",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "8ebcbc60059f25a3cec80b0356718f9500c7a7008dbdd40e7be8a33336fa58f1"
+}

--- a/.sqlx/query-b0922a34af154812b051b863677d1488b3415c365e6b9cf96b5c4eadf0d8d87d.json
+++ b/.sqlx/query-b0922a34af154812b051b863677d1488b3415c365e6b9cf96b5c4eadf0d8d87d.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = $1 ORDER BY ordinal_position",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "column_name",
+        "type_info": "Name"
+      },
+      {
+        "ordinal": 1,
+        "name": "data_type",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Name"
+      ]
+    },
+    "nullable": [
+      true,
+      true
+    ]
+  },
+  "hash": "b0922a34af154812b051b863677d1488b3415c365e6b9cf96b5c4eadf0d8d87d"
+}

--- a/.sqlx/query-dbf468679e62f680f4a90dcba0b49112fac3d3104ef3f8201a5035e2436c77fd.json
+++ b/.sqlx/query-dbf468679e62f680f4a90dcba0b49112fac3d3104ef3f8201a5035e2436c77fd.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT last_block FROM event_descriptor WHERE chain_id = $1 AND event_hash = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "last_block",
+        "type_info": "Numeric"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Numeric",
+        "Bytea"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "dbf468679e62f680f4a90dcba0b49112fac3d3104ef3f8201a5035e2436c77fd"
+}

--- a/.sqlx/query-f6040eceb8c955868750ba20839d303543c86d1fd82b01f2841ef39b92a49bb4.json
+++ b/.sqlx/query-f6040eceb8c955868750ba20839d303543c86d1fd82b01f2841ef39b92a49bb4.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE event_descriptor SET last_block = $1 WHERE chain_id = $2 AND event_hash = ANY($3)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Numeric",
+        "Numeric",
+        "ByteaArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f6040eceb8c955868750ba20839d303543c86d1fd82b01f2841ef39b92a49bb4"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,6 +1260,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -1481,6 +1484,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "config"
 version = "0.15.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1591,6 +1603,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +1702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1774,6 +1796,12 @@ dependencies = [
  "quote",
  "syn 2.0.108",
 ]
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "duckdb"
@@ -1906,6 +1934,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +2047,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,6 +2130,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2289,12 +2361,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2695,6 +2785,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lexical-core"
@@ -2794,6 +2887,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "libz-rs-sys"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,6 +2971,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,6 +3044,22 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -3075,6 +3204,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,6 +3243,15 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3156,6 +3300,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -3404,6 +3559,7 @@ dependencies = [
  "alloy",
  "anyhow",
  "axum",
+ "cfg-if",
  "clap",
  "config",
  "duckdb",
@@ -3416,6 +3572,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "sqlx",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -3687,6 +3844,26 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4097,6 +4274,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4199,6 +4387,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4206,6 +4403,201 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.12.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.108",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "rust_decimal",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.17",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.5",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.17",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.17",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -4219,6 +4611,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -4713,10 +5116,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-width"
@@ -4822,6 +5246,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4923,6 +5353,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4983,6 +5423,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5006,6 +5455,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5043,6 +5507,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5055,6 +5525,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5064,6 +5540,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5091,6 +5573,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5100,6 +5588,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5115,6 +5609,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5124,6 +5624,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,6 @@ dependencies = [
  "alloy",
  "anyhow",
  "axum",
- "cfg-if",
  "clap",
  "config",
  "duckdb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f609fb6392508278b276906d6247ea44f5777e448db95444fa39e89b7aee896a"
+checksum = "e502b004e05578e537ce0284843ba3dfaf6a0d5c530f5c20454411aded561289"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dcd2b4e208ce5477de90ccdcbd4bde2c8fb06af49a443974e92bb8f2c5e93f"
+checksum = "5c3a590d13de3944675987394715f37537b50b856e3b23a0e66e97d963edbf38"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5655f234985f5ab1e31bef7e02ed11f0a899468cf3300e061e1b96e9e11de0"
+checksum = "0f28f769d5ea999f0d8a105e434f483456a15b4e1fcb08edbbbe1650a497ff6d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f01b6d8e5b4f3222aaf7f18613a7292e2fbc9163fe120649cd1b078ca534349"
+checksum = "990fa65cd132a99d3c3795a82b9f93ec82b81c7de3bab0bf26ca5c73286f7186"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6847d641141b92a1557094aa6c236cbe49c06fb24144d4a21fe6acb970c15888"
+checksum = "09535cbc646b0e0c6fcc12b7597eaed12cf86dff4c4fba9507a61e71b94f30eb"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe3192fca2eb0b0c4b122b3c2d8254496b88a4e810558dddd3ea2f30ad9469df"
+checksum = "1005520ccf89fa3d755e46c1d992a9e795466c2e7921be2145ef1f749c5727de"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4ab3330e491053e9608b2a315f147357bb8acb9377a988c1203f2e8e2b296c9"
+checksum = "72b626409c98ba43aaaa558361bca21440c88fd30df7542c7484b9c7a1489cdb"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e22ff194b1e34b4defd1e257e3fe4dce0eee37451c7757a1510d6b23e7379a"
+checksum = "89924fdcfeee0e0fa42b1f10af42f92802b5d16be614a70897382565663bf7cf"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -306,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a6cbb9f431bdad294eebb5af9b293d6979e633bfe5468d1e87c1421a858265"
+checksum = "0f0dbe56ff50065713ff8635d8712a0895db3ad7f209db9793ad8fcb6b1734aa"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5dde1abc3d582e53d139904fcdd8b2103f0bd03e8f2acb4292edbbaeaa7e6e"
+checksum = "8b56f7a77513308a21a2ba0e9d57785a9d9d2d609e77f4e71a78a1192b83ff2d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a94bdef2710322c6770be08689fee0878c2ad75615b8fc40e05d7f3c9618c0b"
+checksum = "ff01723afc25ec4c5b04de399155bef7b6a96dfde2475492b1b7b4e7a4f46445"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811a573c8080e1b492d488e6a240ec5dd7677d7167e91ce9cb4d0ec1fcac8027"
+checksum = "f91bf006bb06b7d812591b6ac33395cb92f46c6a65cda11ee30b348338214f0f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12df0b34551ca2eab8ec83b56cb709ee5da991737282180d354a659b907f00dc"
+checksum = "212ca1c1dab27f531d3858f8b1a2d6bfb2da664be0c1083971078eb7b71abe4b"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f9f130511b8632686dfe6f9909b38d7ae4c68de3ce17d28991400646a39b25"
+checksum = "5715d0bf7efbd360873518bd9f6595762136b5327a9b759a8c42ccd9b5e44945"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "067b718d2e6ac1bb889341fcc7a250cfa49bcd3ba4f23923f1c1eb1f2b10cb7c"
+checksum = "5ed8531cae8d21ee1c6571d0995f8c9f0652a6ef6452fde369283edea6ab7138"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -485,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acff6b251740ef473932386d3b71657d3825daebf2217fb41a7ef676229225d4"
+checksum = "fb10ccd49d0248df51063fce6b716f68a315dd912d55b32178c883fd48b4021d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9129ef31975d987114c27c9930ee817cf3952355834d47f2fdf4596404507e8"
+checksum = "f4d992d44e6c414ece580294abbadb50e74cfd4eaa69787350a4dfd4b20eaa1b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec1fb08ee484e615f24867c0b154fff5722bb00176102a16868c6532b7c3623"
+checksum = "3f50a9516736d22dd834cc2240e5bf264f338667cc1d9e514b55ec5a78b987ca"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b722073c76f2de7e118d546ee1921c50710f97feb32aed50db94cfa5b663e1"
+checksum = "0a18b541a6197cf9a084481498a766fdf32fefda0c35ea6096df7d511025e9f1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -627,9 +627,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3412d52bb97c6c6cc27ccc28d4e6e8cf605469101193b50b0bd5813b1f990b5"
+checksum = "428aa0f0e0658ff091f8f667c406e034b431cb10abd39de4f507520968acc499"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -643,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.2.1"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04950a13cc4209d8e9b78f306e87782466bad8538c94324702d061ff03e211c9"
+checksum = "b2289a842d02fe63f8c466db964168bb2c7a9fdfb7b24816dbb17d45520575fb"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1760,6 +1760,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +1959,17 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fake"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b0902eb36fbab51c14eda1c186bda119fcff91e5e4e7fc2dd2077298197ce8"
+dependencies = [
+ "deunicode",
+ "either",
+ "rand 0.9.2",
 ]
 
 [[package]]
@@ -2320,6 +2337,8 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
 ]
@@ -2940,11 +2959,11 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
-version = "0.13.0"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -3563,10 +3582,12 @@ dependencies = [
  "clap",
  "config",
  "duckdb",
+ "fake",
  "futures",
  "hex",
  "pretty_assertions",
  "prometheus",
+ "quixote",
  "regex",
  "rstest",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,16 @@ readme = "README.md"
 keywords = ["evm", "indexing", "events", "ethereum"]
 
 [features]
-default = ["duckdb"]
-duckdb = ["dep:duckdb"]
-postgresql = ["dep:sqlx"]
+default = []
 test-utils = ["dep:fake"]
 
 [dependencies]
 alloy = { version = "1.4.0", features = ["rpc-types", "json", "rpc-client", "json-rpc"] }
 anyhow = "1.0.100"
-cfg-if = "1.0"
 axum = { version = "0.8.7", features = ["default", "http2"] }
 hex = "0.4"
 clap = { version = "4.5.51", features = ["derive"] }
-duckdb = { version = "1.4.3", features = ["bundled"], optional = true }
+duckdb = { version = "1.4.3", features = ["bundled"] }
 futures = "0.3.31"
 regex = "1.12.2"
 prometheus = { version = "0.13", default-features = false, features = ["process"] }
@@ -37,7 +34,6 @@ fake = { version = "4.4.0", optional = true }
 [dependencies.sqlx]
 version = "0.8.6"
 features = [ "runtime-tokio", "postgres", "derive", "macros", "migrate", "chrono", "rust_decimal" ]
-optional = true
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,10 @@ tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros", "sync", "
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 config = { version = "0.15.19", default-features = false, features = ["yaml", "async"] }
-sqlx = { version = "0.8.6", features = [ "runtime-tokio", "postgres", "derive", "macros", "migrate", "chrono", "rust_decimal" ], optional = true }
+
+[dependencies.sqlx]
+version = "0.8.6"
+features = [ "runtime-tokio", "postgres", "derive", "macros", "migrate", "chrono", "rust_decimal" ]
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ keywords = ["evm", "indexing", "events", "ethereum"]
 default = ["duckdb"]
 duckdb = ["dep:duckdb"]
 postgresql = ["dep:sqlx"]
+test-utils = ["dep:fake"]
 
 [dependencies]
-alloy = { version = "1.2.1", features = ["rpc-types", "json", "rpc-client", "json-rpc"] }
+alloy = { version = "1.4.0", features = ["rpc-types", "json", "rpc-client", "json-rpc"] }
 anyhow = "1.0.100"
 cfg-if = "1.0"
 axum = { version = "0.8.7", features = ["default", "http2"] }
@@ -31,11 +32,14 @@ tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros", "sync", "
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 config = { version = "0.15.19", default-features = false, features = ["yaml", "async"] }
+fake = { version = "4.4.0", optional = true }
 
 [dependencies.sqlx]
 version = "0.8.6"
 features = [ "runtime-tokio", "postgres", "derive", "macros", "migrate", "chrono", "rust_decimal" ]
+optional = true
 
 [dev-dependencies]
 rstest = "0.26.1"
 pretty_assertions = "1.4.1"
+quixote = { path = ".", features = ["test-utils"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,19 @@ homepage = "https://www.bilinearlabs.io"
 readme = "README.md"
 keywords = ["evm", "indexing", "events", "ethereum"]
 
+[features]
+default = ["duckdb"]
+duckdb = ["dep:duckdb"]
+postgresql = ["dep:sqlx"]
+
 [dependencies]
 alloy = { version = "1.2.1", features = ["rpc-types", "json", "rpc-client", "json-rpc"] }
 anyhow = "1.0.100"
+cfg-if = "1.0"
 axum = { version = "0.8.7", features = ["default", "http2"] }
 hex = "0.4"
 clap = { version = "4.5.51", features = ["derive"] }
-duckdb = { version = "1.4.3", features = ["bundled"] }
+duckdb = { version = "1.4.3", features = ["bundled"], optional = true }
 futures = "0.3.31"
 regex = "1.12.2"
 prometheus = { version = "0.13", default-features = false, features = ["process"] }
@@ -25,6 +31,7 @@ tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros", "sync", "
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 config = { version = "0.15.19", default-features = false, features = ["yaml", "async"] }
+sqlx = { version = "0.8.6", features = [ "runtime-tokio", "postgres", "derive", "macros", "migrate", "chrono", "rust_decimal" ], optional = true }
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/Containerfile
+++ b/Containerfile
@@ -42,7 +42,7 @@ RUN conda tos accept --override-channels --channel https://repo.anaconda.com/pkg
 
 WORKDIR /app
 COPY . .
-RUN cargo build --release
+RUN SQLX_OFFLINE=true cargo build --release
 
 # Runtime stage -------------
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ![GitHub License](https://img.shields.io/github/license/bilinearlabs/quixote?style=flat-square)
 ![Rust](https://img.shields.io/badge/Rust-000000?style=flat-square&logo=rust&logoColor=white)
 ![Duckdb](https://img.shields.io/badge/DuckDB-FFF000?style=flat-square&logo=duckdb&logoColor=black)
+![PostgreSQL](https://img.shields.io/badge/PostgreSQL-4169E1?style=flat-square&logo=postgresql&logoColor=white)
 [![Join our Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white&style=flat-square)](https://discord.gg/Et8BTnVBZS)
 
 
@@ -51,7 +52,7 @@ And the database schema as follows.
 curl http://localhost:9720/db_schema
 ```
 
-You can also pass raw SQL queries as follows. 
+You can also pass raw SQL queries as follows.
 
 ```bash
 curl -X POST http://localhost:9720/raw_query \
@@ -67,7 +68,7 @@ And `quixote` ships with a built-in frontend that you can use to query data in a
 ## Features
 
 - **Simple to run**: Single binary, minimal configuration. Point to an RPC and start indexing.
-- **DuckDB-powered**: Fast analytical queries with SQL. File-based storage, no external services required. Export to Parquet or join with other data sources.
+- **Dual database support**: Choose between DuckDB (file-based, zero setup) or PostgreSQL (scalable, production-ready). See [docs](https://quixote.bilinearlabs.io/database).
 - **Any EVM chain**: Works with Ethereum, Arbitrum, Optimism, Polygon, and any EVM-compatible chain.
 - **Flexible event selection**: Index specific events or entire ABIs. Filter by address, topic, or any indexed parameter.
 - **Built-in REST API**: List events, query contracts, or execute raw SQL via HTTP endpoints.

--- a/docs/quixote/docs/pages/config-file.mdx
+++ b/docs/quixote/docs/pages/config-file.mdx
@@ -3,6 +3,7 @@
 For advanced use cases like event filtering or multi-job indexing, use a YAML config:
 
 ```yaml
+database_backend: duckdb  # Options: duckdb (default), postgresql
 database_path: "quixote_indexer.duckdb"
 api_server_address: "127.0.0.1"
 api_server_port: 9720
@@ -26,6 +27,26 @@ index_jobs:
     events:
       - full_signature: "Transfer(address indexed from, address indexed to, uint256 amount)"
 ```
+
+## Database Backend
+
+You can choose between DuckDB and PostgreSQL:
+
+### DuckDB (Default)
+
+```yaml
+database_backend: duckdb
+database_path: "quixote_indexer.duckdb"
+```
+
+### PostgreSQL
+
+```yaml
+database_backend: postgresql
+database_path: "postgres://user:password@localhost:5432/quixote"
+```
+
+See the [Database](/database) page for detailed setup instructions.
 
 And run as follows:
 

--- a/docs/quixote/docs/pages/database.mdx
+++ b/docs/quixote/docs/pages/database.mdx
@@ -11,7 +11,7 @@ DuckDB is the default backend—file-based, zero configuration, and optimized fo
 quixote -r https://your-rpc-url -c 0xContractAddress -e "YourEvent(...)"
 
 # Or explicitly specify the database file
-quixote --database-backend duckdb -d my_data.duckdb -r https://your-rpc-url ...
+quixote -d my_data.duckdb -r https://your-rpc-url ...
 ```
 
 ### When to use DuckDB
@@ -36,13 +36,16 @@ PostgreSQL is recommended for production deployments with concurrent access, lar
 
 ### CLI Usage
 
+The database backend is automatically detected from the connection string. Simply provide a PostgreSQL connection URL:
+
 ```bash
-quixote --database-backend postgresql \
-  -d "postgres://user:password@localhost:5432/quixote" \
+quixote -d "postgres://user:password@localhost:5432/quixote" \
   -r https://your-rpc-url \
   -c 0xContractAddress \
   -e "YourEvent(...)"
 ```
+
+The backend is automatically detected when the connection string starts with `postgres://` or `postgresql://`.
 
 ### Configuration File
 

--- a/docs/quixote/docs/pages/database.mdx
+++ b/docs/quixote/docs/pages/database.mdx
@@ -1,0 +1,134 @@
+# Database Backend
+
+Quixote supports two database backends, allowing you to choose the best option for your use case.
+
+## DuckDB (Default)
+
+DuckDB is the default backend—file-based, zero configuration, and optimized for analytical queries.
+
+```bash
+# Uses DuckDB by default, storing data in quixote_indexer.duckdb
+quixote -r https://your-rpc-url -c 0xContractAddress -e "YourEvent(...)"
+
+# Or explicitly specify the database file
+quixote --database-backend duckdb -d my_data.duckdb -r https://your-rpc-url ...
+```
+
+### When to use DuckDB
+
+- **Local development**: Quick setup, no external services required
+- **Single-user analytics**: Fast analytical queries on your machine
+- **Quick prototyping**: Get started in seconds
+- **Data export**: Easy export to Parquet or CSV for further analysis
+- **Embedded deployments**: Self-contained, single-file database
+
+### DuckDB Features
+
+- File-based storage (single `.duckdb` file)
+- OLAP-optimized query engine
+- SQL support with analytical extensions
+- Direct Parquet export
+- No server process required
+
+## PostgreSQL
+
+PostgreSQL is recommended for production deployments with concurrent access, larger datasets, or integration with existing infrastructure.
+
+### CLI Usage
+
+```bash
+quixote --database-backend postgresql \
+  -d "postgres://user:password@localhost:5432/quixote" \
+  -r https://your-rpc-url \
+  -c 0xContractAddress \
+  -e "YourEvent(...)"
+```
+
+### Configuration File
+
+```yaml
+database_backend: postgresql
+database_path: "postgres://user:password@localhost:5432/quixote"
+api_server_address: "127.0.0.1"
+api_server_port: 9720
+
+index_jobs:
+  - rpc_url: "https://your-rpc-url"
+    contract: "0xContractAddress"
+    events:
+      - full_signature: "Transfer(address indexed from, address indexed to, uint256 value)"
+```
+
+### PostgreSQL Setup
+
+Before running Quixote with PostgreSQL, you need to create the database and run migrations:
+
+```bash
+# Install sqlx-cli if you haven't already
+cargo install sqlx-cli --no-default-features --features postgres
+
+# Set the database URL
+export DATABASE_URL="postgres://user:password@localhost:5432/quixote"
+
+# Create the database
+sqlx database create
+
+# Run migrations
+sqlx migrate run
+```
+
+Alternatively, use the provided setup script:
+
+```bash
+# Set your PostgreSQL credentials
+export POSTGRES_USER=postgres
+export POSTGRES_PASSWORD=your_password
+export POSTGRES_DB=quixote
+
+# Skip Docker if PostgreSQL is already running
+export SKIP_DOCKER=1
+
+# Run the setup script
+./script/init_postgresql.bash
+```
+
+### When to use PostgreSQL
+
+- **Production deployments**: Battle-tested, reliable database
+- **Concurrent access**: Multiple readers/writers supported
+- **Large datasets**: Scales to terabytes of data
+- **Existing infrastructure**: Integrate with your current PostgreSQL setup
+- **Advanced features**: Full PostgreSQL ecosystem (replication, backups, extensions)
+
+### PostgreSQL Features
+
+- Client-server architecture
+- ACID transactions
+- Concurrent read/write access
+- Built-in replication and high availability
+- Rich extension ecosystem
+- Standard SQL with advanced features
+
+## Comparison
+
+| Feature | DuckDB | PostgreSQL |
+|---------|--------|------------|
+| Setup | Zero config | Requires server |
+| Storage | Single file | Client-server |
+| Concurrency | Limited | Full support |
+| Analytics | Excellent | Good |
+| Scalability | Moderate | Excellent |
+| Best for | Development, analytics | Production, multi-user |
+
+## Switching Backends
+
+:::warning
+Switching between backends requires re-indexing your data. There is no automatic migration between DuckDB and PostgreSQL.
+:::
+
+To switch backends:
+
+1. Stop Quixote
+2. Update your configuration to use the new backend
+3. Create a new database (for PostgreSQL, run migrations)
+4. Restart Quixote—it will re-index from your configured start block

--- a/docs/quixote/docs/pages/get-started.mdx
+++ b/docs/quixote/docs/pages/get-started.mdx
@@ -89,7 +89,11 @@ Options:
           Example => 28837711
           Default: 0
   -d, --database <DATABASE>
-          Path to the database file. Default: etherduck_indexer.duckdb
+          Path to the database file or connection string.
+          For DuckDB: path to .duckdb file (default: quixote_indexer.duckdb)
+          For PostgreSQL: connection URL (e.g., postgres://user:pass@host/db)
+      --database-backend <DATABASE_BACKEND>
+          Database backend to use: duckdb (default) or postgresql
   -a, --abi-spec <ABI_SPEC>
           Path for the ABI JSON spec of the indexed contract. When give, the entire set of events defined in the ABI will be indexed.
   -j, --api-server <API_SERVER>

--- a/docs/quixote/docs/pages/get-started.mdx
+++ b/docs/quixote/docs/pages/get-started.mdx
@@ -89,11 +89,10 @@ Options:
           Example => 28837711
           Default: 0
   -d, --database <DATABASE>
-          Path to the database file or connection string.
+          Path to the database file or PostgreSQL connection string.
           For DuckDB: path to .duckdb file (default: quixote_indexer.duckdb)
           For PostgreSQL: connection URL (e.g., postgres://user:pass@host/db)
-      --database-backend <DATABASE_BACKEND>
-          Database backend to use: duckdb (default) or postgresql
+          The backend is automatically detected from the connection string.
   -a, --abi-spec <ABI_SPEC>
           Path for the ABI JSON spec of the indexed contract. When give, the entire set of events defined in the ABI will be indexed.
   -j, --api-server <API_SERVER>

--- a/docs/quixote/docs/pages/index.mdx
+++ b/docs/quixote/docs/pages/index.mdx
@@ -4,7 +4,7 @@ content:
 layout: landing
 showLogo: false
 title: quixote
-description: Simple and flexible Rust-based EVM event indexer powered by DuckDB.
+description: Simple and flexible Rust-based EVM event indexer with DuckDB and PostgreSQL support.
 ---
 
 import { HomePage } from "vocs/components";
@@ -97,9 +97,11 @@ import { HomePage } from "vocs/components";
             <span className="text-[#919193]">built with</span>
             <span className="text-black dark:text-white font-medium">🦀 Rust</span>
           </a>
-          <a href="https://duckdb.org" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-yellow-400/30 hover:border-yellow-400/60 hover:bg-yellow-400/5 transition-all text-[13px]" rel="noreferrer noopener" target="_blank">
+          <a href="/database" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-yellow-400/30 hover:border-yellow-400/60 hover:bg-yellow-400/5 transition-all text-[13px]">
             <span className="text-[#919193]">powered by</span>
             <span className="text-yellow-500 font-medium">🦆 DuckDB</span>
+            <span className="text-[#919193]">/</span>
+            <span className="text-blue-500 font-medium">🐘 PostgreSQL</span>
           </a>
           <a href="https://github.com/bilinearlabs/quixote/blob/main/LICENSE" className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-black/10 dark:border-white/20 hover:border-black/20 dark:hover:border-white/30 hover:bg-black/5 dark:hover:bg-white/5 transition-all text-[13px]" rel="noreferrer noopener" target="_blank">
             <span className="text-[#919193]">license</span>
@@ -121,9 +123,9 @@ import { HomePage } from "vocs/components";
       </div>
       <div className="pl-2 pr-2 max-sm:px-0 max-lg:pb-3 max-lg:pr-0 w-1/4 max-lg:w-1/2 max-sm:w-full z-0">
         <div className="relative w-full h-[168px] max-lg:h-[142px]">
-          <a href="/get-started" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full">
-            <div className="text-2xl font-medium text-black dark:text-white">DuckDB-Powered</div>
-            <div className="text-[19px] max-sm:text-[16px] text-[#919193] break-words">Blazing-fast analytical queries on your indexed data with SQL.</div>
+          <a href="/database" className="hover:bg-black/2 dark:hover:bg-white/2 border-black/10 dark:border-white/10 border border-solid rounded-lg h-full px-5 py-6 absolute z-10 flex flex-col justify-between w-full">
+            <div className="text-2xl font-medium text-black dark:text-white">Dual DB Support</div>
+            <div className="text-[19px] max-sm:text-[16px] text-[#919193] break-words">DuckDB for analytics or PostgreSQL for production. Your choice.</div>
           </a>
           <div className="absolute left-0 right-0 top-0 bottom-0 dark:bg-[#313136] opacity-20 z-0" />
           <div className="absolute left-0 right-0 top-0 bottom-0 backdrop-filter backdrop-blur-[2px] z-0" />
@@ -166,7 +168,7 @@ Just point it at an RPC, specify the events you care about, and start querying y
 ## Why quixote?
 
 - **Simple & Easy to Run**: Single binary and minimal configuration. Just point to an RPC and start indexing. Great as a dev tool.
-- **DuckDB-Powered**: Built on DuckDB for fast analytical queries and file-based storage, without requiring extra services.
+- **Dual Database Support**: Choose DuckDB for zero-config analytics or PostgreSQL for production deployments.
 - **Any EVM Chain**: Works with Ethereum, Arbitrum, Optimism, Polygon, and any EVM-compatible chain.
 - **Arbitrary Events**: Index any event from any smart contract. Just provide the event signature or ABI with optional filters.
 - **Auto Resume**: Automatically resumes from the last synced block. Never lose progress.

--- a/docs/quixote/vocs.config.ts
+++ b/docs/quixote/vocs.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vocs'
 export default defineConfig({
   //basePath: '/quixote',
   title: 'quixote',
-  description: 'Simple and flexible Rust-based EVM event indexer powered by DuckDB.',
+  description: 'Simple and flexible Rust-based EVM event indexer with DuckDB and PostgreSQL support.',
   logoUrl: '/quixote.png',
   iconUrl: '/quixote.png',
   theme: {
@@ -27,6 +27,10 @@ export default defineConfig({
     {
       text: 'Get Started',
       link: '/get-started',
+    },
+    {
+      text: 'Database',
+      link: '/database',
     },
     {
       text: 'Examples',

--- a/migrations/20260116083154_init_db_schema.sql
+++ b/migrations/20260116083154_init_db_schema.sql
@@ -1,0 +1,16 @@
+-- Initial DB schema for Quixote v0.1.0
+
+CREATE TABLE IF NOT EXISTS quixote_info (
+    version VARCHAR NOT NULL,
+    PRIMARY KEY (version)
+);
+
+CREATE TABLE IF NOT EXISTS event_descriptor(
+    chain_id NUMERIC(20,0) NOT NULL,
+    event_hash BYTEA NOT NULL,
+    event_signature BYTEA NOT NULL,
+    event_name VARCHAR(40) NOT NULL,
+    first_block NUMERIC(20,0),
+    last_block NUMERIC(20,0),
+    PRIMARY KEY (chain_id, event_hash)
+);

--- a/migrations/20260116083154_init_db_schema.sql
+++ b/migrations/20260116083154_init_db_schema.sql
@@ -14,3 +14,5 @@ CREATE TABLE IF NOT EXISTS event_descriptor(
     last_block NUMERIC(20,0),
     PRIMARY KEY (chain_id, event_hash)
 );
+
+INSERT INTO quixote_info (version) VALUES ('0.1.0');

--- a/script/init_postgresql.bash
+++ b/script/init_postgresql.bash
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Run this script to initialize a PostgreSQL database for Quixote.
+
+# Uncomment to enable debug mode
+#set -x
+
+set -eo pipefail
+
+# if ! [ -x "$(command -v psql)" ]; then
+#     echo >&2 "Error: psql is not installed."
+#     exit 1
+# fi
+if ! [ -x "$(command -v sqlx)" ]; then
+    echo >&2 "Error: sqlx is not installed."
+    echo >&2 "Use:"
+    echo >&2 "
+    cargo install --version=0.8.6 sqlx-cli --no-default-features --features postgres"
+    echo >&2 "to install it."
+    exit 1
+fi
+
+# Check if a custom user has been set, otherwise default to 'postgres'
+DB_USER=${POSTGRES_USER:=postgres}
+# Check if a custom password has been set, otherwise default to 'password'
+DB_PASSWORD="${POSTGRES_PASSWORD:=password}"
+# Check if a custom database name has been set, otherwise default to 'newsletter'
+DB_NAME="${POSTGRES_DB:=quixote}"
+# Check if a custom port has been set, otherwise default to '5432'
+DB_PORT="${POSTGRES_PORT:=5432}"
+
+# Allow to skip Docker if a dockerized Postgres database is already running
+if [[ -z "${SKIP_DOCKER}" ]]
+then
+    podman run \
+        -e POSTGRES_USER=${DB_USER} \
+        -e POSTGRES_PASSWORD=${DB_PASSWORD} \
+        -e POSTGRES_DB=${DB_NAME} \
+        -p "${DB_PORT}":5432 \
+        -d postgres \
+        postgres -N 1000
+fi
+
+# Let the container start up
+sleep 10
+
+# ^ Increased maximum number of connections for testing purposes
+export DATABASE_URL=postgres://${DB_USER}:${DB_PASSWORD}@localhost:${DB_PORT}/${DB_NAME}
+sqlx database create
+sqlx migrate run
+
+>&2 echo "Postgres has been migrated, ready to go!"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,11 +43,9 @@ pub struct IndexingArgs {
     #[arg(
         short,
         long,
-        help = "Path to the database file. Default: etherduck_indexer.duckdb"
+        help = "Path to the database file or PostgreSQL connection string. Default: etherduck_indexer.duckdb\nFor PostgreSQL, use: postgres://user:password@host:port/database"
     )]
     pub database: Option<String>,
-    #[arg(long, help = "Database backend to use: duckdb (default) or postgresql")]
-    pub database_backend: Option<String>,
     #[arg(
         short,
         long,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,8 @@ pub struct IndexingArgs {
         help = "Path to the database file. Default: etherduck_indexer.duckdb"
     )]
     pub database: Option<String>,
+    #[arg(long, help = "Database backend to use: duckdb (default) or postgresql")]
+    pub database_backend: Option<String>,
     #[arg(
         short,
         long,

--- a/src/collector_seed.rs
+++ b/src/collector_seed.rs
@@ -556,10 +556,10 @@ impl CollectorSeed {
     }
 }
 
-#[cfg(all(test, feature = "duckdb"))]
+#[cfg(test)]
 mod tests {
     use super::*;
-    use crate::configuration::{EventJob, FilterMap, IndexJob};
+    use crate::configuration::{DatabaseBackend, EventJob, FilterMap, IndexJob};
     use crate::storage::DuckDBStorage;
     use alloy::{json_abi::Event, primitives::address};
     use pretty_assertions::assert_eq;
@@ -605,6 +605,7 @@ mod tests {
                 }]),
                 abi_path: None,
             }],
+            database_backend: DatabaseBackend::DuckDb,
             database_path: ":memory:".to_string(),
             api_server_address: "127.0.0.1".to_string(),
             api_server_port: 9720,
@@ -632,6 +633,7 @@ mod tests {
                 events: None,
                 abi_path: Some("test/fixtures/usdc_abi.json".to_string()),
             }],
+            database_backend: DatabaseBackend::DuckDb,
             database_path: ":memory:".to_string(),
             api_server_address: "127.0.0.1".to_string(),
             api_server_port: 9720,
@@ -675,6 +677,7 @@ mod tests {
                     abi_path: None,
                 },
             ],
+            database_backend: DatabaseBackend::DuckDb,
             database_path: ":memory:".to_string(),
             api_server_address: "127.0.0.1".to_string(),
             api_server_port: 9720,
@@ -711,6 +714,7 @@ mod tests {
                 }]),
                 abi_path: None,
             }],
+            database_backend: DatabaseBackend::DuckDb,
             database_path: ":memory:".to_string(),
             api_server_address: "127.0.0.1".to_string(),
             api_server_port: 9720,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,14 +80,10 @@ pub mod storage {
     pub mod storage_api;
     pub use storage_api::{Storage, StorageFactory};
 
-    #[cfg(feature = "duckdb")]
     pub mod storage_duckdb;
-    #[cfg(feature = "duckdb")]
     pub use storage_duckdb::DuckDBStorage;
 
-    #[cfg(feature = "postgresql")]
     pub mod storage_postgresql;
-    #[cfg(feature = "postgresql")]
     pub use storage_postgresql::PostgreSqlStorage;
 
     use serde::Serialize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,3 +155,6 @@ pub struct EventStatus {
     pub last_block: u64,
     pub event_count: usize,
 }
+
+#[cfg(feature = "test-utils")]
+pub mod test_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,16 @@ pub mod error_codes {
 pub mod storage {
     pub mod storage_api;
     pub use storage_api::{Storage, StorageFactory};
+
+    #[cfg(feature = "duckdb")]
     pub mod storage_duckdb;
+    #[cfg(feature = "duckdb")]
     pub use storage_duckdb::DuckDBStorage;
+
+    #[cfg(feature = "postgresql")]
+    pub mod storage_postgresql;
+    #[cfg(feature = "postgresql")]
+    pub use storage_postgresql::PostgreSqlStorage;
 
     use serde::Serialize;
 

--- a/src/storage/storage_postgresql.rs
+++ b/src/storage/storage_postgresql.rs
@@ -1072,7 +1072,8 @@ mod tests {
     async fn latest_block(pool: Pool<Postgres>) -> Result<()> {
         let storage = PostgreSqlStorage::new(pool.clone());
 
-        let num_logs = (Faker.fake::<u8>() % 50 + 1) as usize;
+        // Need at least 2 logs to ensure both event types are represented (logs cycle through event kinds)
+        let num_logs = (Faker.fake::<u8>() % 50 + 2) as usize;
 
         // Insert logs containing 2 different event types. Repeat for 2 different chains.
         let logs = LogTestFixture::builder()

--- a/src/storage/storage_postgresql.rs
+++ b/src/storage/storage_postgresql.rs
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Bilinear Labs
+// SPDX-License-Identifier: MIT
+
+//! Module that handles the connection to the PostgreSQL database.
+
+use crate::{
+    EventStatus,
+    storage::{ContractDescriptorDb, EventDescriptorDb, Storage},
+};
+use alloy::{json_abi::Event, primitives::B256, rpc::types::Log};
+use anyhow::Result;
+use serde_json::Value;
+use sqlx::{Pool, Postgres};
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+#[derive(Clone)]
+pub struct PostgreSqlStorage {
+    conn: Pool<Postgres>,
+    strict_mode: bool,
+    event_descriptors: Arc<RwLock<HashMap<String, Event>>>,
+}
+
+impl Storage for PostgreSqlStorage {
+    fn add_events(&self, _chain_id: u64, _events: &[Log]) -> Result<()> {
+        Ok(())
+    }
+
+    fn list_indexed_events(&self) -> Result<Vec<EventDescriptorDb>> {
+        Ok(vec![])
+    }
+
+    fn event_index_status(&self, _chain_id: u64, _event: &Event) -> Result<Option<EventStatus>> {
+        Ok(None)
+    }
+
+    fn include_events(&self, _chain_id: u64, _events: &[Event]) -> Result<()> {
+        Ok(())
+    }
+
+    fn get_event_signature(&self, _event_hash: &str) -> Result<String> {
+        Ok(String::new())
+    }
+
+    fn last_block(&self, _chain_id: u64, _event: &Event) -> Result<u64> {
+        Ok(0)
+    }
+
+    fn first_block(&self, _chain_id: u64, _event: &Event) -> Result<u64> {
+        Ok(0)
+    }
+
+    fn set_first_block(&self, _chain_id: u64, _event: &Event, _block_number: u64) -> Result<()> {
+        // TODO: Implement PostgreSQL set_first_block
+        Ok(())
+    }
+
+    fn synchronize_events(
+        &self,
+        _chain_id: u64,
+        _event_selectors: &[B256],
+        _last_processed: Option<u64>,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn send_raw_query(&self, _query: &str) -> Result<Value> {
+        Ok(Value::Null)
+    }
+
+    fn list_contracts(&self) -> Result<Vec<ContractDescriptorDb>> {
+        Ok(vec![])
+    }
+
+    fn describe_database(&self) -> Result<Value> {
+        // TODO: Implement PostgreSQL schema introspection
+        Ok(Value::Array(vec![]))
+    }
+}
+
+impl PostgreSqlStorage {
+    pub fn new(conn: Pool<Postgres>) -> Self {
+        Self {
+            conn,
+            strict_mode: false,
+            event_descriptors: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn set_strict_mode(&mut self, strict_mode: bool) {
+        self.strict_mode = strict_mode;
+    }
+}
+
+impl super::StorageFactory for PostgreSqlStorage {
+    fn create_storage(&self) -> Result<Box<dyn super::Storage>> {
+        // Cloning is cheap - Pool is Arc internally
+        Ok(Box::new(self.clone()))
+    }
+}

--- a/src/storage/storage_postgresql.rs
+++ b/src/storage/storage_postgresql.rs
@@ -7,14 +7,22 @@ use crate::{
     EventStatus,
     storage::{ContractDescriptorDb, EventDescriptorDb, Storage},
 };
-use alloy::{json_abi::Event, primitives::B256, rpc::types::Log};
-use anyhow::Result;
+use alloy::{
+    dyn_abi::{DecodedEvent, DynSolValue, EventExt},
+    json_abi::Event,
+    primitives::B256,
+    rpc::types::Log,
+};
+use anyhow::{Context, Result};
 use serde_json::Value;
-use sqlx::{Pool, Postgres};
+use sqlx::{Column, Pool, Postgres, Row, TypeInfo, types::Decimal};
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
     sync::{Arc, RwLock},
 };
+use tracing::{debug, info, warn};
 
 #[derive(Clone)]
 pub struct PostgreSqlStorage {
@@ -24,63 +32,755 @@ pub struct PostgreSqlStorage {
 }
 
 impl Storage for PostgreSqlStorage {
-    fn add_events(&self, _chain_id: u64, _events: &[Log]) -> Result<()> {
+    fn add_events(
+        &self,
+        chain_id: u64,
+        events: &[Log],
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        let pool = self.conn.clone();
+        let events = events.to_vec();
+        let event_descriptors = self.event_descriptors.clone();
+        let strict_mode = self.strict_mode;
+
+        Box::pin(async move {
+            // Quick check to avoid unnecessary operations.
+            if events.is_empty() {
+                info!("No events for the given block range");
+                return Ok(());
+            }
+
+            // Start a transaction
+            let mut tx = pool.begin().await?;
+
+            // First stage: insert the new blocks into the chain-specific blocks table.
+            // Use INSERT ... ON CONFLICT DO NOTHING to ignore duplicates without aborting the transaction.
+            let mut last_block_number = 0u64;
+            for event in &events {
+                if let Some(block_number) = event.block_number
+                    && block_number != last_block_number
+                {
+                    let block_hash = event
+                        .block_hash
+                        .map(|h| h.as_slice().to_vec())
+                        .unwrap_or_default();
+                    let block_timestamp = event.block_timestamp.unwrap_or_default();
+
+                    let insert_block = format!(
+                        "INSERT INTO blocks_{} (block_number, block_hash, block_timestamp) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
+                        chain_id
+                    );
+                    sqlx::query(&insert_block)
+                        .bind(Decimal::from(block_number))
+                        .bind(&block_hash)
+                        .bind(Decimal::from(block_timestamp))
+                        .execute(&mut *tx)
+                        .await?;
+
+                    last_block_number = block_number;
+                }
+            }
+
+            // Second stage: insert the new events into the event_X table.
+
+            // Group events by table so all the events going to the same table can be later inserted at once.
+            let mut events_by_table: HashMap<String, Vec<&Log>> = HashMap::new();
+
+            for log in &events {
+                if log.block_number.is_none()
+                    || log.topic0().is_none()
+                    || log.transaction_hash.is_none()
+                {
+                    continue;
+                }
+
+                let event_hash = log.topic0().unwrap().to_string();
+                let short_hash = PostgreSqlStorage::short_hash(&event_hash);
+                let cache_key = format!("{}:{}", chain_id, short_hash);
+
+                let event_desc = event_descriptors
+                    .read()
+                    .map_err(|_| anyhow::anyhow!("Failed to acquire read lock"))?
+                    .get(&cache_key)
+                    .cloned();
+
+                match event_desc {
+                    Some(event) => {
+                        let table_name = format!(
+                            "event_{}_{}_{}",
+                            chain_id,
+                            event.name.as_str().to_ascii_lowercase(),
+                            short_hash
+                        );
+                        events_by_table.entry(table_name).or_default().push(log);
+                    }
+                    None => {
+                        if strict_mode {
+                            return Err(anyhow::anyhow!(
+                                "Event {event_hash} on chain {chain_id:#x} not found. Include it or disable strict mode."
+                            ));
+                        } else {
+                            warn!("Event {event_hash} on chain {chain_id:#x} not found, skipping.");
+                        }
+                    }
+                }
+            }
+
+            // Process each table's events
+            for (table_name, table_events) in events_by_table {
+                if table_events.is_empty() {
+                    continue;
+                }
+
+                let short_hash = table_name.split('_').nth(3).unwrap();
+                let cache_key = format!("{}:{}", chain_id, short_hash);
+
+                let parsed_event = event_descriptors
+                    .read()
+                    .map_err(|_| anyhow::anyhow!("Failed to acquire read lock"))?
+                    .get(&cache_key)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("Event descriptor not found"))?;
+
+                let event_hash = table_events
+                    .first()
+                    .and_then(|l| l.topic0())
+                    .map(|h| h.to_string())
+                    .unwrap_or_default();
+                let mut max_block_number: u64 = 0;
+
+                for log in table_events {
+                    let block_number = log.block_number.unwrap();
+                    let tx_hash = log.transaction_hash.unwrap().as_slice().to_vec();
+                    let log_index = log.log_index.unwrap() as i32;
+                    let contract_address = log.address().as_slice().to_vec();
+
+                    max_block_number = max_block_number.max(block_number);
+
+                    // Decode event parameters - store value and whether it's a uint256
+                    let mut param_values: Vec<(String, bool)> = Vec::new();
+                    if let Ok(DecodedEvent { indexed, body, .. }) = parsed_event
+                        .decode_log_parts(log.topics().to_vec(), log.data().data.as_ref())
+                    {
+                        // Process indexed parameters
+                        for (i, item) in indexed.iter().enumerate() {
+                            let is_uint256 = parsed_event
+                                .inputs
+                                .get(i)
+                                .map(|p| p.selector_type() == "uint256")
+                                .unwrap_or(false);
+                            param_values.push((
+                                PostgreSqlStorage::dyn_sol_value_to_string(item),
+                                is_uint256,
+                            ));
+                        }
+                        // Process body parameters (non-indexed)
+                        let indexed_count = indexed.len();
+                        for (i, item) in body.iter().enumerate() {
+                            let is_uint256 = parsed_event
+                                .inputs
+                                .get(indexed_count + i)
+                                .map(|p| p.selector_type() == "uint256")
+                                .unwrap_or(false);
+                            param_values.push((
+                                PostgreSqlStorage::dyn_sol_value_to_string(item),
+                                is_uint256,
+                            ));
+                        }
+                    }
+
+                    // Build column names for this event
+                    let param_names: Vec<String> = parsed_event
+                        .inputs
+                        .iter()
+                        .map(|p| format!("\"{}\"", p.name))
+                        .collect();
+                    let all_columns = format!(
+                        "block_number, transaction_hash, log_index, contract_address{}",
+                        if param_names.is_empty() {
+                            String::new()
+                        } else {
+                            format!(", {}", param_names.join(", "))
+                        }
+                    );
+
+                    // Build placeholders
+                    let placeholder_count = 4 + param_values.len();
+                    let placeholders: Vec<String> =
+                        (1..=placeholder_count).map(|i| format!("${}", i)).collect();
+
+                    let insert_sql = format!(
+                        "INSERT INTO {} ({}) VALUES ({}) ON CONFLICT DO NOTHING",
+                        table_name,
+                        all_columns,
+                        placeholders.join(", ")
+                    );
+
+                    let mut query = sqlx::query(&insert_sql)
+                        .bind(Decimal::from(block_number))
+                        .bind(&tx_hash)
+                        .bind(log_index)
+                        .bind(&contract_address);
+
+                    for (val, is_uint256) in &param_values {
+                        if *is_uint256 {
+                            // Parse as Decimal for NUMERIC columns
+                            let decimal_val = val.parse::<Decimal>().unwrap_or_default();
+                            query = query.bind(decimal_val);
+                        } else {
+                            query = query.bind(val);
+                        }
+                    }
+
+                    query.execute(&mut *tx).await?;
+                }
+
+                // Update last_block for this event
+                let event_hash_bytes =
+                    hex::decode(event_hash.trim_start_matches("0x")).unwrap_or_default();
+                sqlx::query!(
+                    "UPDATE event_descriptor SET last_block = $1 WHERE chain_id = $2 AND event_hash = $3",
+                    Decimal::from(max_block_number),
+                    Decimal::from(chain_id),
+                    event_hash_bytes,
+                )
+                .execute(&mut *tx)
+                .await?;
+            }
+
+            tx.commit().await?;
         Ok(())
+        })
     }
 
-    fn list_indexed_events(&self) -> Result<Vec<EventDescriptorDb>> {
-        Ok(vec![])
+    fn list_indexed_events(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<EventDescriptorDb>>> + Send + '_>> {
+        let pool = self.conn.clone();
+
+        Box::pin(async move {
+            // Query all event descriptors
+            let rows = sqlx::query!(
+                "SELECT chain_id, event_hash, event_signature, event_name, first_block, last_block FROM event_descriptor"
+            )
+            .fetch_all(&pool)
+            .await?;
+
+            let mut events: Vec<EventDescriptorDb> = rows
+                .into_iter()
+                .map(|row| EventDescriptorDb {
+                    chain_id: Some(u64::try_from(row.chain_id).unwrap_or(0)),
+                    event_hash: Some(format!("0x{}", hex::encode(&row.event_hash))),
+                    event_signature: Some(
+                        String::from_utf8_lossy(&row.event_signature).to_string(),
+                    ),
+                    event_name: Some(row.event_name.clone()),
+                    first_block: row.first_block.map(|d| u64::try_from(d).unwrap_or(0)),
+                    last_block: row.last_block.map(|d| u64::try_from(d).unwrap_or(0)),
+                    event_count: None,
+                })
+                .collect();
+
+            // Populate event counts for each event
+            for event in events.iter_mut() {
+                if let (Some(chain_id), Some(event_hash), Some(event_name)) = (
+                    event.chain_id,
+                    event.event_hash.as_ref(),
+                    event.event_name.as_ref(),
+                ) {
+                    let short_hash = PostgreSqlStorage::short_hash(event_hash);
+                    let table_name = format!(
+                        "event_{}_{}_{}",
+                        chain_id,
+                        event_name.to_ascii_lowercase(),
+                        short_hash
+                    );
+
+                    let count_query = format!("SELECT COUNT(*) FROM {}", table_name);
+                    let count: i64 = sqlx::query_scalar(&count_query)
+                        .fetch_one(&pool)
+                        .await
+                        .unwrap_or(0);
+
+                    event.event_count = Some(count as usize);
+                }
+            }
+
+            Ok(events)
+        })
     }
 
-    fn event_index_status(&self, _chain_id: u64, _event: &Event) -> Result<Option<EventStatus>> {
-        Ok(None)
+    fn event_index_status(
+        &self,
+        chain_id: u64,
+        event: &Event,
+    ) -> Pin<Box<dyn Future<Output = Result<Option<EventStatus>>> + Send + '_>> {
+        let pool = self.conn.clone();
+        let event_hash = event.selector().to_string();
+        let event_hash_bytes = event.selector().as_slice().to_owned();
+
+        Box::pin(async move {
+            // Query event_descriptor for this event
+            let row = sqlx::query!(
+                "SELECT event_name, first_block, last_block FROM event_descriptor WHERE chain_id = $1 AND event_hash = $2",
+                Decimal::from(chain_id),
+                event_hash_bytes,
+            )
+            .fetch_optional(&pool)
+            .await?;
+
+            let Some(record) = row else {
+                return Ok(None);
+            };
+
+            let first_block_u64 = record
+                .first_block
+                .map(|d| u64::try_from(d).unwrap_or(0))
+                .unwrap_or(0);
+            let last_block_u64 = record
+                .last_block
+                .map(|d| u64::try_from(d).unwrap_or(0))
+                .unwrap_or(0);
+
+            let mut event_status = EventStatus {
+                hash: event_hash.clone(),
+                first_block: first_block_u64,
+                last_block: last_block_u64,
+                event_count: 0,
+            };
+
+            // If we have processed blocks, count the events
+            if last_block_u64 != 0 {
+                let short_hash = PostgreSqlStorage::short_hash(&event_hash);
+                let table_name = format!(
+                    "event_{}_{}_{}",
+                    chain_id,
+                    record.event_name.to_ascii_lowercase(),
+                    short_hash
+                );
+
+                let count_query = format!("SELECT COUNT(*) FROM {}", table_name);
+                let event_count: i64 = sqlx::query_scalar(&count_query)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap_or(0);
+
+                event_status.event_count = event_count as usize;
+            }
+
+            Ok(Some(event_status))
+        })
     }
 
-    fn include_events(&self, _chain_id: u64, _events: &[Event]) -> Result<()> {
+    fn include_events(
+        &self,
+        chain_id: u64,
+        events: &[Event],
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        let pool = self.conn.clone();
+        // Clone events to own them in the async block
+        let events: Vec<Event> = events.to_vec();
+
+        Box::pin(async move {
+            // Create the blocks table for this chain
+            let create_blocks_table = format!(
+                r#"
+                CREATE TABLE IF NOT EXISTS blocks_{chain_id}(
+                    block_number NUMERIC(20,0) NOT NULL,
+                    block_hash BYTEA NOT NULL,
+                    block_timestamp NUMERIC(20,0) NOT NULL,
+                    PRIMARY KEY (block_number)
+                )
+                "#
+            );
+            sqlx::query(&create_blocks_table)
+                .execute(&pool)
+                .await
+                .context("Failed to create blocks table")?;
+
+            // Create tables and register each event
+            for event in &events {
+                // Table name format: event_<chain_id>_<name>_<short_hash>
+                let event_hash = event.selector().to_string();
+                let short_hash = PostgreSqlStorage::short_hash(&event_hash);
+                let event_name = event.name.as_str().to_ascii_lowercase();
+
+                debug!(
+                    "Creating event schema for chain {:#x}: {}",
+                    chain_id,
+                    event.full_signature()
+                );
+
+                // Build the table definition
+                let mut create_table = format!(
+                    "CREATE TABLE IF NOT EXISTS event_{chain_id}_{event_name}_{short_hash}(
+                        block_number NUMERIC(20,0) NOT NULL,
+                        transaction_hash BYTEA NOT NULL,
+                        log_index INT NOT NULL,
+                        contract_address BYTEA NOT NULL,"
+                );
+
+                for param in &event.inputs {
+                    let db_type = if param.selector_type() == "uint256" {
+                        "NUMERIC(78,0)"
+                    } else {
+                        "TEXT"
+                    };
+                    create_table.push_str(&format!("\"{}\" {db_type},", param.name));
+                }
+
+                create_table.push_str("PRIMARY KEY (block_number, transaction_hash, log_index))");
+
+                sqlx::query(&create_table).execute(&pool).await?;
+
+                // Create an entry for this event in the event_descriptor table
+                let event_hash_bytes = event.selector().as_slice().to_vec();
+                let event_signature_bytes = event.full_signature().as_bytes().to_vec();
+
+                sqlx::query(
+                    "INSERT INTO event_descriptor (chain_id, event_hash, event_signature, event_name, first_block, last_block) \
+                     VALUES ($1, $2, $3, $4, 0, 0) \
+                     ON CONFLICT (chain_id, event_hash) DO NOTHING"
+                )
+                    .bind(Decimal::from(chain_id))
+                    .bind(&event_hash_bytes)
+                    .bind(&event_signature_bytes)
+                    .bind(&event.name)
+                    .execute(&pool)
+                    .await
+                    .context("Failed to insert event descriptor")?;
+            }
+
+            let mut event_descriptors = self.event_descriptors.write().map_err(|_| {
+                anyhow::anyhow!("Failed to acquire write lock for the event descriptor")
+            })?;
+
+            // Populate the local cache of the indexed events.
+            // Key is chain_id:short_hash to support same event on different chains.
+            for event in events {
+                let selector_str = event.selector().to_string();
+                let short_hash = Self::short_hash(&selector_str);
+                let key = format!("{}:{}", chain_id, short_hash);
+                event_descriptors.insert(key, event.clone());
+            }
+
         Ok(())
+        })
     }
 
-    fn get_event_signature(&self, _event_hash: &str) -> Result<String> {
-        Ok(String::new())
+    fn get_event_signature(
+        &self,
+        event_hash: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<String>> + Send + '_>> {
+        let pool = self.conn.clone();
+        // Convert hex string to bytes (strip 0x prefix if present)
+        let hash_str = event_hash.strip_prefix("0x").unwrap_or(event_hash);
+        let event_hash_bytes = hex::decode(hash_str).unwrap_or_default();
+
+        Box::pin(async move {
+            let signature: Vec<u8> = sqlx::query_scalar!(
+                "SELECT event_signature FROM event_descriptor WHERE event_hash = $1",
+                event_hash_bytes,
+            )
+            .fetch_one(&pool)
+            .await?;
+
+            Ok(String::from_utf8_lossy(&signature).to_string())
+        })
     }
 
-    fn last_block(&self, _chain_id: u64, _event: &Event) -> Result<u64> {
-        Ok(0)
+    fn last_block(
+        &self,
+        chain_id: u64,
+        event: &Event,
+    ) -> Pin<Box<dyn Future<Output = Result<u64>> + Send + '_>> {
+        let pool = self.conn.clone();
+        let event_hash = event.selector().as_slice().to_owned();
+
+        Box::pin(async move {
+            let last_block: Option<Decimal> = sqlx::query_scalar!(
+                "SELECT last_block FROM event_descriptor WHERE chain_id = $1 AND event_hash = $2",
+                Decimal::from(chain_id),
+                event_hash,
+            )
+            .fetch_one(&pool)
+            .await?;
+
+            Ok(last_block
+                .map(|d| u64::try_from(d).unwrap_or(0))
+                .unwrap_or(0))
+        })
     }
 
-    fn first_block(&self, _chain_id: u64, _event: &Event) -> Result<u64> {
-        Ok(0)
+    fn first_block(
+        &self,
+        chain_id: u64,
+        event: &Event,
+    ) -> Pin<Box<dyn Future<Output = Result<u64>> + Send + '_>> {
+        let pool = self.conn.clone();
+        let event_hash = event.selector().as_slice().to_owned();
+
+        Box::pin(async move {
+            let first_block: Option<Decimal> = sqlx::query_scalar!(
+                "SELECT first_block FROM event_descriptor WHERE chain_id = $1 AND event_hash = $2",
+                Decimal::from(chain_id),
+                event_hash,
+            )
+            .fetch_one(&pool)
+            .await?;
+
+            Ok(first_block
+                .map(|d| u64::try_from(d).unwrap_or(0))
+                .unwrap_or(0))
+        })
     }
 
-    fn set_first_block(&self, _chain_id: u64, _event: &Event, _block_number: u64) -> Result<()> {
-        // TODO: Implement PostgreSQL set_first_block
+    fn set_first_block(
+        &self,
+        chain_id: u64,
+        event: &Event,
+        block_number: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        let pool = self.conn.clone();
+        let event_hash = event.selector().as_slice().to_owned();
+
+        Box::pin(async move {
+            sqlx::query!(
+                "UPDATE event_descriptor SET first_block = $1 WHERE chain_id = $2 AND event_hash = $3",
+                Decimal::from(block_number), Decimal::from(chain_id), event_hash,
+            )
+            .execute(&pool)
+            .await?;
         Ok(())
+        })
     }
 
     fn synchronize_events(
         &self,
-        _chain_id: u64,
-        _event_selectors: &[B256],
-        _last_processed: Option<u64>,
-    ) -> Result<()> {
+        chain_id: u64,
+        event_selectors: &[B256],
+        last_processed: Option<u64>,
+    ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        let pool = self.conn.clone();
+        // Convert selectors to owned byte vectors for the async block
+        let selectors: Vec<Vec<u8>> = event_selectors
+            .iter()
+            .map(|s| s.as_slice().to_vec())
+            .collect();
+
+        Box::pin(async move {
+            if selectors.is_empty() {
+                debug!(
+                    "No event selectors provided for synchronize_events on chain {:#x}, skipping",
+                    chain_id
+                );
+                return Ok(());
+            }
+
+            if let Some(last_block) = last_processed {
+                // Update all matching events to the specified last_block
+                sqlx::query!(
+                    "UPDATE event_descriptor SET last_block = $1 WHERE chain_id = $2 AND event_hash = ANY($3)",
+                    Decimal::from(last_block),
+                    Decimal::from(chain_id),
+                    &selectors as &[Vec<u8>],
+                )
+                .execute(&pool)
+                .await?;
+            } else {
+                // Set last_block to the MAX among the specified events
+                sqlx::query!(
+                    "UPDATE event_descriptor SET last_block = (
+                        SELECT MAX(last_block) FROM event_descriptor WHERE chain_id = $1 AND event_hash = ANY($2)
+                    ) WHERE chain_id = $1 AND event_hash = ANY($2)",
+                    Decimal::from(chain_id),
+                    &selectors as &[Vec<u8>],
+                )
+                .execute(&pool)
+                .await?;
+            }
+
+            debug!(
+                "Events synchronized up to block {}",
+                last_processed.unwrap_or_default()
+            );
+
         Ok(())
+        })
     }
 
-    fn send_raw_query(&self, _query: &str) -> Result<Value> {
-        Ok(Value::Null)
+    fn send_raw_query(
+        &self,
+        query: &str,
+    ) -> Pin<Box<dyn Future<Output = Result<Value>> + Send + '_>> {
+        let pool = self.conn.clone();
+        let query = query.to_string();
+
+        Box::pin(async move {
+            // Only allow SELECT statements for safety
+            if !query.trim_start().to_uppercase().starts_with("SELECT") {
+                return Ok(serde_json::json!({ "error": "Query must be a SELECT statement" }));
+            }
+
+            let rows = sqlx::query(&query).fetch_all(&pool).await?;
+
+            let mut results = Vec::new();
+
+            for row in rows {
+                let mut row_obj = serde_json::Map::new();
+
+                for (i, column) in row.columns().iter().enumerate() {
+                    let col_name = column.name().to_string();
+                    let type_name = column.type_info().name();
+
+                    // Convert based on PostgreSQL type
+                    let value: Value = match type_name {
+                        "INT2" | "INT4" => {
+                            let v: Option<i32> = row.try_get(i).ok();
+                            v.map(|n| Value::Number(n.into())).unwrap_or(Value::Null)
+                        }
+                        "INT8" => {
+                            let v: Option<i64> = row.try_get(i).ok();
+                            v.map(|n| Value::Number(n.into())).unwrap_or(Value::Null)
+                        }
+                        "FLOAT4" | "FLOAT8" => {
+                            let v: Option<f64> = row.try_get(i).ok();
+                            v.and_then(serde_json::Number::from_f64)
+                                .map(Value::Number)
+                                .unwrap_or(Value::Null)
+                        }
+                        "NUMERIC" => {
+                            let v: Option<Decimal> = row.try_get(i).ok();
+                            v.map(|d| Value::String(d.to_string()))
+                                .unwrap_or(Value::Null)
+                        }
+                        "BOOL" => {
+                            let v: Option<bool> = row.try_get(i).ok();
+                            v.map(Value::Bool).unwrap_or(Value::Null)
+                        }
+                        "BYTEA" => {
+                            let v: Option<Vec<u8>> = row.try_get(i).ok();
+                            v.map(|b| Value::String(format!("0x{}", hex::encode(b))))
+                                .unwrap_or(Value::Null)
+    }
+                        _ => {
+                            // Default: try as string
+                            let v: Option<String> = row.try_get(i).ok();
+                            v.map(Value::String).unwrap_or(Value::Null)
+                        }
+                    };
+
+                    row_obj.insert(col_name, value);
+                }
+
+                results.push(Value::Object(row_obj));
+            }
+
+            Ok(Value::Array(results))
+        })
     }
 
-    fn list_contracts(&self) -> Result<Vec<ContractDescriptorDb>> {
-        Ok(vec![])
+    fn list_contracts(
+        &self,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<ContractDescriptorDb>>> + Send + '_>> {
+        let pool = self.conn.clone();
+
+        Box::pin(async move {
+            // Get all event descriptors to find their tables
+            let descriptors =
+                sqlx::query!("SELECT chain_id, event_hash, event_name FROM event_descriptor")
+                    .fetch_all(&pool)
+                    .await?;
+
+            let mut contracts = HashSet::new();
+
+            // For each event table, get distinct contract addresses
+            for row in descriptors {
+                let chain_id = u64::try_from(row.chain_id).unwrap_or(0);
+                let event_hash = format!("0x{}", hex::encode(&row.event_hash));
+                let short_hash = PostgreSqlStorage::short_hash(&event_hash);
+                let table_name = format!(
+                    "event_{}_{}_{}",
+                    chain_id,
+                    row.event_name.to_ascii_lowercase(),
+                    short_hash
+                );
+
+                let query = format!("SELECT DISTINCT contract_address FROM {}", table_name);
+                let addresses: Vec<Vec<u8>> = sqlx::query_scalar(&query)
+                    .fetch_all(&pool)
+                    .await
+                    .unwrap_or_default();
+
+                contracts.extend(
+                    addresses
+                        .into_iter()
+                        .map(|bytes| format!("0x{}", hex::encode(bytes))),
+                );
+            }
+
+            Ok(contracts
+                .into_iter()
+                .map(|address| ContractDescriptorDb {
+                    contract_address: address,
+                    contract_name: None,
+                })
+                .collect())
+        })
     }
 
-    fn describe_database(&self) -> Result<Value> {
-        // TODO: Implement PostgreSQL schema introspection
-        Ok(Value::Array(vec![]))
+    fn describe_database(&self) -> Pin<Box<dyn Future<Output = Result<Value>> + Send + '_>> {
+        let pool = self.conn.clone();
+
+        Box::pin(async move {
+            // Get all tables in the public schema, excluding quixote_info
+            let tables: Vec<String> = sqlx::query_scalar(
+                "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name != 'quixote_info'"
+            )
+            .fetch_all(&pool)
+            .await?;
+
+            let mut result = Vec::new();
+
+            // For each table, get its column definitions
+            for table_name in tables {
+                let columns = sqlx::query!(
+                    "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = $1 ORDER BY ordinal_position",
+                    table_name
+                )
+                .fetch_all(&pool)
+                .await?;
+
+                let mut columns_map = serde_json::Map::new();
+                for col in columns {
+                    if let (Some(name), Some(dtype)) = (col.column_name, col.data_type) {
+                        columns_map.insert(name, Value::String(dtype));
+                    }
+                }
+
+                let mut table_obj = serde_json::Map::new();
+                table_obj.insert(table_name, Value::Object(columns_map));
+                result.push(Value::Object(table_obj));
+            }
+
+            Ok(Value::Array(result))
+        })
     }
 }
 
 impl PostgreSqlStorage {
+    /// Length of the short hash used in table names (5 hex characters).
+    const SHORT_HASH_LEN: usize = 5;
+
+    /// Returns a shortened version of an event hash for use in table names.
+    ///
+    /// Takes the first 5 hex characters after the "0x" prefix.
+    /// Example: "0xddf252ad..." -> "ddf25"
+    #[inline]
+    fn short_hash(full_hash: &str) -> &str {
+        let start = if full_hash.starts_with("0x") { 2 } else { 0 };
+        &full_hash[start..start + Self::SHORT_HASH_LEN]
+    }
+
     pub fn new(conn: Pool<Postgres>) -> Self {
         Self {
             conn,
@@ -91,6 +791,36 @@ impl PostgreSqlStorage {
 
     pub fn set_strict_mode(&mut self, strict_mode: bool) {
         self.strict_mode = strict_mode;
+    }
+
+    /// Converts a `DynSolValue` to a String representation for storage.
+    fn dyn_sol_value_to_string(value: &DynSolValue) -> String {
+        match value {
+            DynSolValue::Address(a) => a.to_string().to_lowercase(),
+            DynSolValue::Bool(b) => b.to_string(),
+            DynSolValue::Int(i, _) => i.to_string(),
+            DynSolValue::Uint(u, _) => u.to_string(),
+            DynSolValue::String(s) => s.clone(),
+            DynSolValue::FixedBytes(bytes, size) => {
+                format!("0x{}", hex::encode(&bytes[..(*size).min(32)]))
+            }
+            DynSolValue::Bytes(bytes) => {
+                format!("0x{}", hex::encode(bytes))
+            }
+            DynSolValue::Function(f) => {
+                format!("0x{}", hex::encode(f.as_slice()))
+            }
+            DynSolValue::Array(values) | DynSolValue::FixedArray(values) => {
+                let elements: Vec<String> =
+                    values.iter().map(Self::dyn_sol_value_to_string).collect();
+                format!("[{}]", elements.join(","))
+            }
+            DynSolValue::Tuple(values) => {
+                let elements: Vec<String> =
+                    values.iter().map(Self::dyn_sol_value_to_string).collect();
+                format!("({})", elements.join(","))
+            }
+        }
     }
 }
 

--- a/src/storage/storage_postgresql.rs
+++ b/src/storage/storage_postgresql.rs
@@ -390,14 +390,28 @@ impl Storage for PostgreSqlStorage {
                 return Ok(None);
             };
 
-            let first_block_u64 = record
-                .first_block
-                .map(|d| u64::try_from(d).unwrap_or(0))
-                .unwrap_or(0);
-            let last_block_u64 = record
-                .last_block
-                .map(|d| u64::try_from(d).unwrap_or(0))
-                .unwrap_or(0);
+            let first_block_u64 = u64::try_from(record.first_block.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "first_block is NULL in database for chain_id={} event_hash={}",
+                    chain_id,
+                    event_hash
+                )
+            })?)
+            .context(format!(
+                "Failed to convert first_block to u64 for chain_id={} event_hash={}",
+                chain_id, event_hash
+            ))?;
+            let last_block_u64 = u64::try_from(record.last_block.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "last_block is NULL in database for chain_id={} event_hash={}",
+                    chain_id,
+                    event_hash
+                )
+            })?)
+            .context(format!(
+                "Failed to convert last_block to u64 for chain_id={} event_hash={}",
+                chain_id, event_hash
+            ))?;
 
             let mut event_status = EventStatus {
                 hash: event_hash.clone(),

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 Bilinear Labs
+// SPDX-License-Identifier: MIT
+
+//! Module with utilities for testing.
+
+use alloy::{json_abi::Event, rpc::types::Log};
+use fake::{Fake, Faker};
+use std::str::FromStr;
+
+/// Generates a random Ethereum address (20 bytes, 0x-prefixed)
+pub fn fake_address() -> String {
+    let bytes: [u8; 20] = Faker.fake();
+    format!("0x{}", hex::encode(bytes))
+}
+
+/// Converts an Ethereum address to a topic.
+pub fn address_to_topic(address: &str) -> String {
+    let trimmed = address.trim_start_matches("0x");
+    format!("0x{:0>64}", trimmed)
+}
+
+/// Generates a random uint256 hex value.
+pub fn random_uint256_hex() -> String {
+    let bytes: [u8; 32] = Faker.fake();
+    format!("0x{}", hex::encode(bytes))
+}
+
+/// Picks a random address from a pool.
+pub fn pick_pool_address(pool: &[String]) -> &str {
+    let index = (Faker.fake::<u32>() as usize) % pool.len();
+    pool[index].as_str()
+}
+
+/// ERC20 Transfer event
+pub fn transfer_event() -> Event {
+    Event::from_str("event Transfer(address indexed from, address indexed to, uint256 value)")
+        .expect("failed to parse Transfer event")
+}
+
+/// ERC20 Approval event
+pub fn approval_event() -> Event {
+    Event::from_str("event Approval(address indexed owner, address indexed spender, uint256 value)")
+        .expect("failed to parse Approval event")
+}
+
+/// Mint event (common in many token contracts)
+pub fn mint_event() -> Event {
+    Event::from_str("event Mint(address indexed to, uint256 amount)")
+        .expect("failed to parse Mint event")
+}
+
+/// Burn event
+pub fn burn_event() -> Event {
+    Event::from_str("event Burn(address indexed from, uint256 amount)")
+        .expect("failed to parse Burn event")
+}
+
+/// ERC721 Transfer event
+pub fn erc721_transfer_event() -> Event {
+    Event::from_str(
+        "event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)",
+    )
+    .expect("failed to parse ERC721 Transfer event")
+}
+
+/// Collection of standard ERC20 events
+pub fn erc20_events() -> Vec<Event> {
+    vec![transfer_event(), approval_event()]
+}
+
+/// Collection of token events including mint/burn
+pub fn token_events() -> Vec<Event> {
+    vec![
+        transfer_event(),
+        approval_event(),
+        mint_event(),
+        burn_event(),
+    ]
+}
+
+/// Enum that represents the kind of event for a log.
+#[derive(Copy, Clone)]
+pub enum LogEventKind {
+    Erc20Transfer,
+    Erc20Approval,
+    Erc721Transfer,
+}
+
+/// Fixture for generating logs.
+///
+/// This fixture is used to generate logs for testing. It can be configured to generate logs for different
+/// event kinds and contract addresses.
+pub struct LogTestFixture {
+    log_count: usize,
+    start_block: u64,
+    event_kinds: Vec<LogEventKind>,
+    contract_addresses: Vec<String>,
+    address_pool: Option<Vec<String>>,
+    address_pool_size: usize,
+}
+
+impl LogTestFixture {
+    pub fn builder() -> Self {
+        // Generate a random start block between 1 and 1_000_000
+        let start_block: u64 = (Faker.fake::<u32>() % 1_000_000 + 1) as u64;
+        Self {
+            log_count: 1,
+            start_block,
+            event_kinds: Vec::new(),
+            contract_addresses: Vec::new(),
+            address_pool: None,
+            address_pool_size: 5,
+        }
+    }
+
+    pub fn with_log_count(mut self, log_count: usize) -> Self {
+        self.log_count = log_count;
+        self
+    }
+
+    pub fn with_start_block(mut self, start_block: u64) -> Self {
+        self.start_block = start_block;
+        self
+    }
+
+    pub fn with_contract_addresses<I>(mut self, contract_addresses: I) -> Self
+    where
+        I: IntoIterator<Item = String>,
+    {
+        self.contract_addresses = contract_addresses.into_iter().collect();
+        self
+    }
+
+    pub fn add_contract_address<S>(mut self, address: S) -> Self
+    where
+        S: Into<String>,
+    {
+        self.contract_addresses.push(address.into());
+        self
+    }
+
+    pub fn with_address_pool_size(mut self, size: usize) -> Self {
+        self.address_pool_size = size;
+        self
+    }
+
+    pub fn with_address_pool<I>(mut self, addresses: I) -> Self
+    where
+        I: IntoIterator<Item = String>,
+    {
+        self.address_pool = Some(addresses.into_iter().collect());
+        self
+    }
+
+    pub fn with_erc20_transfer(mut self) -> Self {
+        self.event_kinds.push(LogEventKind::Erc20Transfer);
+        self
+    }
+
+    pub fn with_erc20_approval(mut self) -> Self {
+        self.event_kinds.push(LogEventKind::Erc20Approval);
+        self
+    }
+
+    pub fn with_erc721_transfer(mut self) -> Self {
+        self.event_kinds.push(LogEventKind::Erc721Transfer);
+        self
+    }
+
+    pub fn build(self) -> Vec<Log> {
+        let event_kinds = if self.event_kinds.is_empty() {
+            vec![LogEventKind::Erc20Transfer]
+        } else {
+            self.event_kinds
+        };
+
+        let contract_addresses = if self.contract_addresses.is_empty() {
+            vec![fake_address()]
+        } else {
+            self.contract_addresses
+        };
+
+        let address_pool = match self.address_pool {
+            Some(pool) if !pool.is_empty() => pool,
+            _ => {
+                let pool_size = self.address_pool_size.max(1);
+                (0..pool_size).map(|_| fake_address()).collect()
+            }
+        };
+
+        (0..self.log_count)
+            .map(|i| {
+                let event_kind = event_kinds[i % event_kinds.len()];
+                let contract_address = &contract_addresses[i % contract_addresses.len()];
+                let from_address = pick_pool_address(&address_pool);
+                let to_address = pick_pool_address(&address_pool);
+
+                let (topics, data) = match event_kind {
+                    LogEventKind::Erc20Transfer => (
+                        vec![
+                            transfer_event().selector().to_string(),
+                            address_to_topic(from_address),
+                            address_to_topic(to_address),
+                        ],
+                        random_uint256_hex(),
+                    ),
+                    LogEventKind::Erc20Approval => (
+                        vec![
+                            approval_event().selector().to_string(),
+                            address_to_topic(from_address),
+                            address_to_topic(to_address),
+                        ],
+                        random_uint256_hex(),
+                    ),
+                    LogEventKind::Erc721Transfer => (
+                        vec![
+                            erc721_transfer_event().selector().to_string(),
+                            address_to_topic(from_address),
+                            address_to_topic(to_address),
+                            random_uint256_hex(),
+                        ],
+                        "0x".to_string(),
+                    ),
+                };
+
+                let block_number = self.start_block + i as u64;
+                serde_json::from_value(serde_json::json!({
+                    "address": contract_address,
+                    "topics": topics,
+                    "data": data,
+                    "blockNumber": format!("0x{:x}", block_number),
+                    "transactionHash": format!("0x{:064x}", block_number),
+                    "transactionIndex": "0x0",
+                    "blockHash": format!("0x{:064x}", 0xbabe_u64),
+                    "blockTimestamp": format!("0x{:x}", 1700000000 + block_number),
+                    "logIndex": format!("0x{:x}", i),
+                    "removed": false
+                }))
+                .expect("failed to build log")
+            })
+            .collect()
+    }
+}


### PR DESCRIPTION
Implementation of the `Storage` trait to support a **PostgresSQL** backend.

This PR relates to the feature #53. 

## Main changes:
- Add an implementation for **PostgresSQL** using the framework **SQLx**.
  - Fully tested via unit tests.
  - Fully supported batch inserts using the native support from **PostgresSQL** (no from the framework).
  - Add a migration to set up a new instance of **PostgresSQL**.
- Add a script to launch a development **PostgresSQL** container using Docker.
- Prepare the SQL queries that allow a static analysis to be checked without needing a DB backend running.
- Extend the CI workflow to include a **PostgresSQL** DB to run all the new tests.
- Add a new test module that generates fixtures for Logs (emulate the payload from an RPC server).
- Add docs related to the new backend.

Closes: #53  