### PR TITLE
Fix no contract

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,7 +25,6 @@ pub struct IndexingArgs {
     #[arg(
         short,
         long,
-        required_unless_present = "config",
         help = "Contract to index.\nExample: 0x1234567890123456789012345678901234567890"
     )]
     pub contract: Option<String>,


### PR DESCRIPTION
* Running `quixote` without specifying a contract is possible.
* But as it is, it was only possible via a config file.
* This PR allows to not pass the `--contract` flag.

In other words, this was failing:
```
./target/release/quixote \
  --rpc-host "redacted" \
  --event "Transfer(address indexed from, address indexed to, uint256 value)" \
  --start-block 20000000 \
  --database-backend postgresql \
  --database "redacted" \
  --verbosity 2
```

```
error: the following required arguments were not provided:
  --contract <CONTRACT>
```

And this PR fixes it.