### PR TITLE
Fix for block range logic

### DIFF
--- a/src/event_collector.rs
+++ b/src/event_collector.rs
@@ -221,10 +221,9 @@ impl EventCollector {
                             chunk_length >> 1
                         };
 
+                        // Check for situations in which the hint for the range yields 0 (1-1)
                         if chunk_length == 0 {
-                            return Err(anyhow::anyhow!(
-                                "Block range reduced to zero, cannot continue the indexing."
-                            ));
+                            chunk_length = 1;
                         }
 
                         warn!(


### PR DESCRIPTION
This fix applies when the hint received by the RPC server yields 0. This happens when the amount of logs it too big, and the RPC advises to request a single block at a time. As subtracting the interval bounds yields 0, the existing logic breaks.

