### PR TITLE
Tor integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 quixote_frontend_env/*
 .env
 **node_modules**
+.vscode

--- a/.sqlx/query-136cba5ded20e26779ffa8945da080177b5152480c818066ecd6047343652e8e.json
+++ b/.sqlx/query-136cba5ded20e26779ffa8945da080177b5152480c818066ecd6047343652e8e.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT first_block FROM event_descriptor WHERE event_hash = $1 AND chain_id = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "first_block",
+        "type_info": "Numeric"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bytea",
+        "Numeric"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "136cba5ded20e26779ffa8945da080177b5152480c818066ecd6047343652e8e"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "zeroize",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,7 +110,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.0.1",
  "either",
  "k256",
  "once_cell",
@@ -228,7 +240,7 @@ dependencies = [
  "auto_impl",
  "borsh",
  "c-kzg",
- "derive_more",
+ "derive_more 2.0.1",
  "either",
  "serde",
  "serde_with",
@@ -297,7 +309,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more",
+ "derive_more 2.0.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -327,7 +339,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more",
+ "derive_more 2.0.1",
  "foldhash 0.2.0",
  "hashbrown 0.16.0",
  "indexmap 2.12.0",
@@ -596,7 +608,7 @@ dependencies = [
  "alloy-json-rpc",
  "auto_impl",
  "base64",
- "derive_more",
+ "derive_more 2.0.1",
  "futures",
  "futures-utils-wasm",
  "parking_lot",
@@ -634,7 +646,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arrayvec",
- "derive_more",
+ "derive_more 2.0.1",
  "nybbles",
  "serde",
  "smallvec",
@@ -647,10 +659,56 @@ version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2289a842d02fe63f8c466db964168bb2c7a9fdfb7b24816dbb17d45520575fb"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "amplify"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7fb4ac7c881e54a8e7015e399b6112a2a5bc958b6c89ac510840ff20273b31"
+dependencies = [
+ "amplify_derive",
+ "amplify_num",
+ "ascii",
+ "getrandom 0.2.16",
+ "getrandom 0.3.4",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "amplify_derive"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a6309e6b8d89b36b9f959b7a8fa093583b94922a0f6438a24fb08936de4d428"
+dependencies = [
+ "amplify_syn",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "amplify_num"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99bcb75a2982047f733547042fc3968c0f460dfcf7d90b90dea3b2744580e9ad"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "amplify_syn"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7736fb8d473c0d83098b5bac44df6a561e20470375cd8bcae30516dc889fd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -777,7 +835,7 @@ dependencies = [
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "educe",
+ "educe 0.6.0",
  "itertools 0.13.0",
  "num-bigint",
  "num-traits",
@@ -1055,7 +1113,7 @@ version = "56.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3aa9e59c611ebc291c28582077ef25c97f1975383f1479b12f3b9ffee2ffabe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1087,6 +1145,121 @@ dependencies = [
  "num",
  "regex",
  "regex-syntax",
+]
+
+[[package]]
+name = "arti-client"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57064cebe248bf9c0e1df2cce40926cfd9c8cad9c3103c53c594c6c5f7794d8b"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "derive-deftly 0.14.6",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "educe 0.4.23",
+ "fs-mistrust",
+ "futures",
+ "hostname-validator",
+ "humantime",
+ "humantime-serde",
+ "libc",
+ "postage",
+ "rand 0.8.5",
+ "safelog",
+ "serde",
+ "thiserror 1.0.69",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-chanmgr",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirmgr",
+ "tor-error",
+ "tor-guardmgr",
+ "tor-hsclient",
+ "tor-hscrypto",
+ "tor-hsservice",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-rtcompat",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "futures-io",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-native-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9343dc5acf07e79ff82d0c37899f079db3534d99f189a1837c8e549c99405bec"
+dependencies = [
+ "futures-util",
+ "native-tls",
+ "thiserror 1.0.69",
+ "url",
 ]
 
 [[package]]
@@ -1123,12 +1296,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_executors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a982d2f86de6137cc05c9db9a915a19886c97911f9790d04f174cede74be01a5"
+dependencies = [
+ "blanket",
+ "futures-core",
+ "futures-task",
+ "futures-util",
+ "pin-project",
+ "rustc_version 0.4.1",
+ "tokio",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "atomic"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -1257,9 +1473,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -1274,6 +1496,17 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blanket"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1321,10 +1554,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "bounded-vec-deque"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2225b558afc76c596898f5f1b3fc35cfce0eb1b13635cbd7d1b2a7177dc10ccd"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1355,6 +1611,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1645,12 @@ dependencies = [
  "once_cell",
  "serde",
 ]
+
+[[package]]
+name = "caret"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061dc3258f029feaf9ff02b43c6af5ea67a7dfaed5d2aef36204c812e614ef9c"
 
 [[package]]
 name = "cast"
@@ -1427,6 +1695,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,7 +1724,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -1467,6 +1746,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "coarsetime"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e58eb270476aa4fc7843849f8a35063e8743b4dbcdf6dd0f8ea0886980c204c2"
+dependencies = [
+ "libc",
+ "wasix",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1772,25 @@ dependencies = [
  "strum_macros 0.26.4",
  "unicode-width",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "liblzma",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "concurrent-queue"
@@ -1561,6 +1870,43 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+dependencies = [
+ "futures",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1646,13 +1992,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
 name = "darling"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1666,8 +2072,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "strsim",
+ "strsim 0.11.1",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core 0.14.4",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1676,7 +2093,7 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.108",
 ]
@@ -1696,6 +2113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +2127,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "cookie-factory",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1728,6 +2165,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-deftly"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8ea84d0109517cc2253d4a679bdda1e8989e9bd86987e9e4f75ffdda0095fd1"
+dependencies = [
+ "derive-deftly-macros 0.14.6",
+ "heck",
+]
+
+[[package]]
+name = "derive-deftly"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0798e47e69cc4e23b3d506c1070cebd2eaa8e51cbac1c688887e481397988681"
+dependencies = [
+ "derive-deftly-macros 1.11.0",
+ "heck",
+]
+
+[[package]]
+name = "derive-deftly-macros"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357422a457ccb850dc8f1c1680e0670079560feaad6c2e247e3f345c4fab8a3f"
+dependencies = [
+ "heck",
+ "indexmap 2.12.0",
+ "itertools 0.14.0",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "strum 0.27.2",
+ "syn 2.0.108",
+ "void",
+]
+
+[[package]]
+name = "derive-deftly-macros"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f268b637848f736f5a86be4e40cabf5ca788f9af6399feef348ac8b942734b90"
+dependencies = [
+ "heck",
+ "indexmap 2.12.0",
+ "itertools 0.14.0",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "sha3",
+ "strum 0.27.2",
+ "syn 2.0.108",
+ "unicode-ident",
+ "void",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,12 +2233,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder_core_fork_arti"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c1b715c79be6328caa9a5e1a387a196ea503740f0722ec3dd8f67a9e72314d"
+dependencies = [
+ "darling 0.14.4",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_builder_fork_arti"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3eae24d595f4d0ecc90a9a5a6d11c2bd8dafe2375ec4a1ec63250e5ade7d228"
+dependencies = [
+ "derive_builder_macro_fork_arti",
+]
+
+[[package]]
+name = "derive_builder_macro_fork_arti"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69887769a2489cd946bf782eb2b1bb2cb7bc88551440c94a765d4f040c08ebf3"
+dependencies = [
+ "derive_builder_core_fork_arti",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.0.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1753,6 +2300,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
+ "convert_case 0.7.1",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -1793,6 +2341,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.5.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,6 +2409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "duckdb"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,7 +2424,7 @@ dependencies = [
  "cast",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.10.0",
  "libduckdb-sys",
  "num-integer",
  "rust_decimal",
@@ -1854,12 +2459,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "merlin",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "educe"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0042ff8246a363dbe77d2ceedb073339e85a804b9a47636c6e016a9a32c05f"
+dependencies = [
+ "enum-ordinalize 3.1.15",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "educe"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
 dependencies = [
- "enum-ordinalize",
+ "enum-ordinalize 4.3.2",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -1901,6 +2544,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf1fa3f06bbff1ea5b1a9c7b14aa992a39657db60a2759457328d7e058f49ee"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2023,6 +2679,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic 0.6.1",
+ "serde",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2064,6 +2739,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluid-let"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "749cff877dc1af878a0b31a41dd221a753634401ea0ef2f87b62d3171522485a"
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,12 +2774,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-mistrust"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28d81b7d2feb4197784e984a09c9799404a7793ed2352a54cb2aff98a31d48a"
+dependencies = [
+ "derive_builder_fork_arti",
+ "dirs 5.0.1",
+ "libc",
+ "once_cell",
+ "pwd-grp",
+ "serde",
+ "thiserror 2.0.17",
+ "walkdir",
+]
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fslock-arti-fork"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b21bd626aaab7b904b20bef6d9e06298914a0c8d9fb8b010483766b2e532791"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "fslock-guard"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed387b899db1671a47eaf17e7e6d7008577262c09319cb8e19601371192b526f"
+dependencies = [
+ "fslock-arti-fork",
+ "thiserror 2.0.17",
+ "winapi",
 ]
 
 [[package]]
@@ -2264,6 +3007,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "glob-match"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2272,6 +3021,18 @@ dependencies = [
  "ff",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "growable-bloom-filter"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d174ccb4ba660d431329e7f0797870d0a4281e36353ec4b4a3c5eab6c2cfb6f1"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -2319,6 +3080,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2341,6 +3105,15 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
  "serde",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -2407,6 +3180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname-validator"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f558a64ac9af88b5ba400d99b579451af0d39c6d360980045b91aac966d705e2"
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,6 +3230,22 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -2561,7 +3356,7 @@ checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
- "tinystr",
+ "tinystr 0.8.2",
  "writeable",
  "zerovec",
 ]
@@ -2692,6 +3487,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,6 +3609,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "k12"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4dc5fdb62af2f520116927304f15d25b3c2667b4817b90efdc045194c912c54"
+dependencies = [
+ "digest 0.10.7",
+ "sha3",
+]
+
+[[package]]
 name = "k256"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,6 +3649,26 @@ checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -2889,6 +3761,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "liblzma"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6033b77c21d1f56deeae8014eb9fbe7bdf1765185a6c508b5ca82eeaed7f899"
+dependencies = [
+ "liblzma-sys",
+]
+
+[[package]]
+name = "liblzma-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a60851d15cd8c5346eca4ab8babff585be2ae4bc8097c067291d3ffe2add3b6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2900,7 +3792,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "libc",
  "redox_syscall",
 ]
@@ -2984,6 +3876,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3006,10 +3907,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core 0.6.4",
+ "zeroize",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3028,8 +3956,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "notify"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+dependencies = [
+ "bitflags 2.11.1",
+ "filetime",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+dependencies = [
+ "instant",
 ]
 
 [[package]]
@@ -3163,6 +4146,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -3193,6 +4177,121 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "oneshot-fused-workaround"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2948fd2414b613f9a97f8401270bd5d7638265ab940475cdbcfa28a0273d58"
+dependencies = [
+ "futures",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
+]
 
 [[package]]
 name = "parity-scale-codec"
@@ -3289,6 +4388,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3348,6 +4489,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "postage"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3fb618632874fb76937c2361a7f22afd393c982a2165595407edc75b06d3c1"
+dependencies = [
+ "atomic 0.5.3",
+ "crossbeam-queue",
+ "futures",
+ "parking_lot",
+ "pin-project",
+ "static_assertions",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3382,6 +4538,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3393,12 +4558,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "priority-queue"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
+dependencies = [
+ "equivalent",
+ "indexmap 2.12.0",
+ "serde",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.7",
 ]
 
 [[package]]
@@ -3438,7 +4614,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hex",
  "lazy_static",
  "procfs-core",
@@ -3451,7 +4627,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hex",
 ]
 
@@ -3479,7 +4655,7 @@ checksum = "bee689443a2bd0a16ab0348b52ee43e3b2d1b1f931c8aa5c9f8de4c86fbe8c40"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.1",
  "num-traits",
  "rand 0.9.2",
  "rand_chacha 0.9.0",
@@ -3508,6 +4684,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "pwd-grp"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e2023f41b5fcb7c30eb5300a5733edfaa9e0e0d502d51b586f65633fd39e40c"
+dependencies = [
+ "derive-deftly 1.11.0",
+ "libc",
+ "paste",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3577,6 +4765,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anyhow",
+ "arti-client",
  "async-trait",
  "axum",
  "clap",
@@ -3585,6 +4774,8 @@ dependencies = [
  "fake",
  "futures",
  "hex",
+ "hyper",
+ "hyper-util",
  "pretty_assertions",
  "prometheus",
  "quixote",
@@ -3595,6 +4786,8 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "tor-cell",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3697,7 +4890,29 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3805,6 +5020,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "retry-error"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce97442758392c7e2a7716e06c514de75f0fe4b5a4b76e14ba1e5edfb7ba3512"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3881,6 +5102,7 @@ dependencies = [
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
+ "sha2",
  "signature",
  "spki",
  "subtle",
@@ -3951,6 +5173,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+ "time",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3997,12 +5234,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4015,7 +5261,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -4080,6 +5326,47 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "safelog"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a4e1c994fbc7521a5003e5c1c54304654ea0458881e777f6e2638520c2de8c5"
+dependencies = [
+ "derive_more 2.0.1",
+ "educe 0.4.23",
+ "either",
+ "fluid-let",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "sanitize-filename"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ed72fbaf78e6f2d41744923916966c4fbe3d7c74e3037a8ee482f1115572603"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "schemars"
@@ -4164,6 +5451,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4198,6 +5508,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4215,6 +5545,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4239,6 +5579,15 @@ dependencies = [
  "itoa",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4278,7 +5627,7 @@ version = "3.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91a903660542fced4e99881aa481bdbaec1634568ee02e0b8bd57c64cb38955"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
@@ -4346,6 +5695,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "bstr",
+ "dirs 6.0.0",
+ "os_str_bytes",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4383,10 +5743,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
+name = "slotmap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd58c3c93c3d278ca835519292445cb4b0d4dc59ccfdf7ceadaab3f8aeb4038"
+dependencies = [
+ "serde",
+ "version_check",
+]
+
+[[package]]
+name = "slotmap-careful"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9500059071474a36baac642b6bb99ca1dbac0ce43727abbba02dad83822dadf2"
+dependencies = [
+ "paste",
+ "serde",
+ "slotmap",
+ "thiserror 2.0.17",
+ "void",
+]
 
 [[package]]
 name = "smallvec"
@@ -4457,7 +5846,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.12.0",
  "log",
  "memchr",
@@ -4521,7 +5910,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -4565,7 +5954,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64",
- "bitflags",
+ "bitflags 2.11.1",
  "byteorder",
  "chrono",
  "crc",
@@ -4622,6 +6011,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "cipher",
+ "ssh-encoding",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4646,6 +6076,12 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -4655,6 +6091,9 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
 
 [[package]]
 name = "strum"
@@ -4880,6 +6319,15 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+]
+
+[[package]]
+name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
@@ -4961,9 +6409,31 @@ checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4977,12 +6447,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.12.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap 2.12.0",
- "toml_datetime",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "winnow",
 ]
@@ -4994,6 +6478,967 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tor-async-utils"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3157a36bca68d25da943d9e77804fb1dadca108cd124871668a18763eae735b6"
+dependencies = [
+ "derive-deftly 0.14.6",
+ "educe 0.4.23",
+ "futures",
+ "oneshot-fused-workaround",
+ "pin-project",
+ "postage",
+ "thiserror 1.0.69",
+ "void",
+]
+
+[[package]]
+name = "tor-basic-utils"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3915f18c6574f797c5d59089074f79f81e6d93495d726179eebc9084126d617e"
+dependencies = [
+ "derive_more 1.0.0",
+ "hex",
+ "itertools 0.13.0",
+ "libc",
+ "paste",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "serde",
+ "slab",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "tor-bytes"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6cef6d87b08baf1475bc24da39343705ab9b4f7f916d0ee19fa657634733d0d"
+dependencies = [
+ "bytes",
+ "derive-deftly 0.14.6",
+ "digest 0.10.7",
+ "educe 0.4.23",
+ "getrandom 0.2.16",
+ "safelog",
+ "thiserror 1.0.69",
+ "tor-error",
+ "tor-llcrypto",
+ "zeroize",
+]
+
+[[package]]
+name = "tor-cell"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35443109312b7ea355d767afc696d00389604a6afa6144a44ba074f7290bbb6b"
+dependencies = [
+ "amplify",
+ "bitflags 2.11.1",
+ "bytes",
+ "caret",
+ "derive-deftly 0.14.6",
+ "derive_more 1.0.0",
+ "educe 0.4.23",
+ "paste",
+ "rand 0.8.5",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cert",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-units",
+ "void",
+]
+
+[[package]]
+name = "tor-cert"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b8eaa55aa20a3cab77943e176ed48f34c90d9ba0dc98c64adef6c15aef0bc8"
+dependencies = [
+ "caret",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "digest 0.10.7",
+ "thiserror 1.0.69",
+ "tor-bytes",
+ "tor-checkable",
+ "tor-llcrypto",
+]
+
+[[package]]
+name = "tor-chanmgr"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0eabe776706c7062468bb7fdab05136c7a9db6325e9688e02d47a7b6d6dee9d"
+dependencies = [
+ "async-trait",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "educe 0.4.23",
+ "futures",
+ "oneshot-fused-workaround",
+ "postage",
+ "rand 0.8.5",
+ "safelog",
+ "serde",
+ "thiserror 1.0.69",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-cell",
+ "tor-config",
+ "tor-error",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-proto",
+ "tor-rtcompat",
+ "tor-socksproto",
+ "tor-units",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "tor-checkable"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c1d164cf835d4f5e4150293e8322e152e8d8a39839cfea219742556df8fbe2"
+dependencies = [
+ "humantime",
+ "signature",
+ "thiserror 1.0.69",
+ "tor-llcrypto",
+]
+
+[[package]]
+name = "tor-circmgr"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24638de4d36226023345c0e5f40e0e2244d2f6aec118b9c7cdb464c8f5f6277"
+dependencies = [
+ "amplify",
+ "async-trait",
+ "bounded-vec-deque",
+ "cfg-if",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "downcast-rs",
+ "dyn-clone",
+ "educe 0.4.23",
+ "futures",
+ "humantime-serde",
+ "itertools 0.13.0",
+ "once_cell",
+ "oneshot-fused-workaround",
+ "pin-project",
+ "rand 0.8.5",
+ "retry-error",
+ "safelog",
+ "serde",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-chanmgr",
+ "tor-config",
+ "tor-error",
+ "tor-guardmgr",
+ "tor-linkspec",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-protover",
+ "tor-relay-selection",
+ "tor-rtcompat",
+ "tracing",
+ "void",
+ "weak-table",
+]
+
+[[package]]
+name = "tor-config"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a89f7cc30d911d5baf61a181b15ea16219d5a63b54ff87bd3e05d3814ad212"
+dependencies = [
+ "amplify",
+ "cfg-if",
+ "derive-deftly 0.14.6",
+ "derive_builder_fork_arti",
+ "directories",
+ "educe 0.4.23",
+ "either",
+ "figment",
+ "fs-mistrust",
+ "futures",
+ "itertools 0.13.0",
+ "notify",
+ "once_cell",
+ "paste",
+ "postage",
+ "regex",
+ "serde",
+ "serde-value",
+ "serde_ignored",
+ "shellexpand",
+ "strum 0.26.3",
+ "thiserror 1.0.69",
+ "toml",
+ "tor-basic-utils",
+ "tor-config-path",
+ "tor-error",
+ "tor-rtcompat",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "tor-config-path"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebee676fe2b0c76c262e107a11a996cb381ff484d136c218becea6a4c15be5a"
+dependencies = [
+ "directories",
+ "once_cell",
+ "serde",
+ "shellexpand",
+ "thiserror 1.0.69",
+ "tor-error",
+]
+
+[[package]]
+name = "tor-consdiff"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fd67886ae74b82d4cf7a15bc34c7381d10287178b3f9e8d92311cb74b761b1"
+dependencies = [
+ "digest 0.10.7",
+ "hex",
+ "thiserror 1.0.69",
+ "tor-llcrypto",
+]
+
+[[package]]
+name = "tor-dirclient"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65ac0b04c4ff8c303a291ab22aa453c73929895b16a8314d888a7d0269c8343"
+dependencies = [
+ "async-compression",
+ "base64ct",
+ "derive_more 1.0.0",
+ "futures",
+ "hex",
+ "http",
+ "httparse",
+ "httpdate",
+ "itertools 0.13.0",
+ "memchr",
+ "thiserror 1.0.69",
+ "tor-circmgr",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-netdoc",
+ "tor-proto",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
+name = "tor-dirmgr"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3a3e12af4860040f28cb14b03f9fae18a9aa0f1e66dab77ef0d9f93026ba95b"
+dependencies = [
+ "async-trait",
+ "base64ct",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "digest 0.10.7",
+ "educe 0.4.23",
+ "event-listener",
+ "fs-mistrust",
+ "fslock",
+ "futures",
+ "hex",
+ "humantime",
+ "humantime-serde",
+ "itertools 0.13.0",
+ "memmap2",
+ "once_cell",
+ "oneshot-fused-workaround",
+ "paste",
+ "postage",
+ "rand 0.8.5",
+ "rusqlite",
+ "safelog",
+ "scopeguard",
+ "serde",
+ "signature",
+ "strum 0.26.3",
+ "thiserror 1.0.69",
+ "time",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-consdiff",
+ "tor-dirclient",
+ "tor-error",
+ "tor-guardmgr",
+ "tor-llcrypto",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
+name = "tor-error"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82249e99eeab846b0264aabb761bceba891b9a5e5875fd2644683feeb96ea417"
+dependencies = [
+ "derive_more 1.0.0",
+ "futures",
+ "once_cell",
+ "paste",
+ "retry-error",
+ "static_assertions",
+ "strum 0.26.3",
+ "thiserror 1.0.69",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "tor-general-addr"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3279be11b11750ea2bb85cc6ac81f22223696650400834d8e64c9449136b593e"
+dependencies = [
+ "derive_more 1.0.0",
+ "thiserror 1.0.69",
+ "void",
+]
+
+[[package]]
+name = "tor-guardmgr"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a732a0331e57b852512dcba2e2cecac1b7e9aee91e231b1d7373f8d6ca4aa1a"
+dependencies = [
+ "amplify",
+ "base64ct",
+ "derive-deftly 0.14.6",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "dyn-clone",
+ "educe 0.4.23",
+ "futures",
+ "humantime",
+ "humantime-serde",
+ "itertools 0.13.0",
+ "num_enum",
+ "oneshot-fused-workaround",
+ "pin-project",
+ "postage",
+ "rand 0.8.5",
+ "safelog",
+ "serde",
+ "strum 0.26.3",
+ "thiserror 1.0.69",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-config",
+ "tor-error",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-relay-selection",
+ "tor-rtcompat",
+ "tor-units",
+ "tracing",
+]
+
+[[package]]
+name = "tor-hsclient"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ac236cd5ea5e96590e10adaf71cb0f48678d24da59b724b9cc7cfa552a14ba0"
+dependencies = [
+ "async-trait",
+ "derive-deftly 0.14.6",
+ "derive_more 1.0.0",
+ "educe 0.4.23",
+ "either",
+ "futures",
+ "itertools 0.13.0",
+ "oneshot-fused-workaround",
+ "postage",
+ "rand 0.8.5",
+ "retry-error",
+ "safelog",
+ "slotmap-careful",
+ "strum 0.26.3",
+ "thiserror 1.0.69",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirclient",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-rtcompat",
+ "tracing",
+]
+
+[[package]]
+name = "tor-hscrypto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00099189e52d3376082b58139759249f16a53119d3d4f5f023168881c87d0a0"
+dependencies = [
+ "cipher",
+ "data-encoding",
+ "derive-deftly 0.14.6",
+ "derive_more 1.0.0",
+ "digest 0.10.7",
+ "itertools 0.13.0",
+ "paste",
+ "rand 0.8.5",
+ "safelog",
+ "signature",
+ "subtle",
+ "thiserror 1.0.69",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-error",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-units",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "tor-hsservice"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eaf9ac91fff7b5e009da2a4c88b34db4ee8d6416a8cd2907659e715641169bd"
+dependencies = [
+ "amplify",
+ "async-trait",
+ "base64ct",
+ "cfg-if",
+ "derive-deftly 0.14.6",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "digest 0.10.7",
+ "educe 0.4.23",
+ "fs-mistrust",
+ "futures",
+ "growable-bloom-filter",
+ "hex",
+ "humantime",
+ "itertools 0.13.0",
+ "k12",
+ "once_cell",
+ "oneshot-fused-workaround",
+ "postage",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "retry-error",
+ "safelog",
+ "serde",
+ "serde_with",
+ "strum 0.26.3",
+ "thiserror 1.0.69",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirclient",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-log-ratelim",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-protover",
+ "tor-relay-selection",
+ "tor-rtcompat",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "tor-key-forge"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "814a3ceb5b1c0a790f3604f2745775ca4a2cac3499a00c8641fc03030e068e08"
+dependencies = [
+ "derive-deftly 0.14.6",
+ "derive_more 1.0.0",
+ "downcast-rs",
+ "paste",
+ "rand 0.8.5",
+ "signature",
+ "ssh-key",
+ "thiserror 1.0.69",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-llcrypto",
+]
+
+[[package]]
+name = "tor-keymgr"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335a589e149aa728b09c1614a76f9857993c133c2b0fa03319c41218f4bde975"
+dependencies = [
+ "amplify",
+ "arrayvec",
+ "cfg-if",
+ "derive-deftly 0.14.6",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "downcast-rs",
+ "dyn-clone",
+ "fs-mistrust",
+ "glob-match",
+ "humantime",
+ "inventory",
+ "itertools 0.13.0",
+ "rand 0.8.5",
+ "serde",
+ "signature",
+ "ssh-key",
+ "thiserror 1.0.69",
+ "tor-basic-utils",
+ "tor-config",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-key-forge",
+ "tor-llcrypto",
+ "tor-persist",
+ "tracing",
+ "walkdir",
+ "zeroize",
+]
+
+[[package]]
+name = "tor-linkspec"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc92002b84c1cdea158aac4a3a400d61dd02fae5d9d0e8a36a8e08cd64fda6e9"
+dependencies = [
+ "base64ct",
+ "by_address",
+ "caret",
+ "derive-deftly 0.14.6",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "hex",
+ "itertools 0.13.0",
+ "safelog",
+ "serde",
+ "serde_with",
+ "strum 0.26.3",
+ "thiserror 1.0.69",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-config",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-protover",
+]
+
+[[package]]
+name = "tor-llcrypto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877d2fae2ef8f29ad91bd434e195bdef98662839be9ed4befdf071956b093123"
+dependencies = [
+ "aes",
+ "base64ct",
+ "ctr",
+ "curve25519-dalek",
+ "der-parser",
+ "derive-deftly 0.14.6",
+ "derive_more 1.0.0",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "educe 0.4.23",
+ "getrandom 0.2.16",
+ "hex",
+ "rand_core 0.6.4",
+ "rsa",
+ "safelog",
+ "serde",
+ "sha1",
+ "sha2",
+ "sha3",
+ "signature",
+ "subtle",
+ "thiserror 1.0.69",
+ "tor-memquota",
+ "visibility",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "tor-log-ratelim"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b090937d1bde6910769b2be6b514fc1c07e83f646a14a471f8f2647367afd10"
+dependencies = [
+ "futures",
+ "humantime",
+ "once_cell",
+ "thiserror 1.0.69",
+ "tor-error",
+ "tor-rtcompat",
+ "tracing",
+ "weak-table",
+]
+
+[[package]]
+name = "tor-memquota"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4560cc9485af7c499f611e2ed565dfcf1445e804faad0dd47ad097f4e9bf7d2"
+dependencies = [
+ "derive-deftly 0.14.6",
+ "derive_more 1.0.0",
+ "dyn-clone",
+ "educe 0.4.23",
+ "futures",
+ "itertools 0.13.0",
+ "paste",
+ "pin-project",
+ "serde",
+ "slotmap-careful",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-config",
+ "tor-error",
+ "tor-log-ratelim",
+ "tor-rtcompat",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "tor-netdir"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a99ad35659954aa280e678c3af2ab68934caaf55b94b947e2fb6f850598b5a"
+dependencies = [
+ "bitflags 2.11.1",
+ "derive_more 1.0.0",
+ "digest 0.10.7",
+ "futures",
+ "hex",
+ "humantime",
+ "itertools 0.13.0",
+ "num_enum",
+ "rand 0.8.5",
+ "serde",
+ "static_assertions",
+ "strum 0.26.3",
+ "thiserror 1.0.69",
+ "time",
+ "tor-basic-utils",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-netdoc",
+ "tor-protover",
+ "tor-units",
+ "tracing",
+ "typed-index-collections",
+]
+
+[[package]]
+name = "tor-netdoc"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f74630f9b13b192e84e09a0b39460eec8d1d23f6fa4b45f03d06782322d583fb"
+dependencies = [
+ "amplify",
+ "base64ct",
+ "bitflags 2.11.1",
+ "cipher",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "digest 0.10.7",
+ "educe 0.4.23",
+ "hex",
+ "humantime",
+ "itertools 0.13.0",
+ "once_cell",
+ "phf",
+ "rand 0.8.5",
+ "serde",
+ "serde_with",
+ "signature",
+ "smallvec",
+ "subtle",
+ "thiserror 1.0.69",
+ "time",
+ "tinystr 0.7.6",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-cert",
+ "tor-checkable",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-protover",
+ "tor-units",
+ "void",
+ "weak-table",
+ "zeroize",
+]
+
+[[package]]
+name = "tor-persist"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b035192b529f6316c77d969f1e3be9f85d61ca1e1f946c91a96f987fdaba5e"
+dependencies = [
+ "amplify",
+ "derive-deftly 0.14.6",
+ "derive_more 1.0.0",
+ "filetime",
+ "fs-mistrust",
+ "fslock",
+ "fslock-guard",
+ "futures",
+ "itertools 0.13.0",
+ "oneshot-fused-workaround",
+ "paste",
+ "sanitize-filename",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-error",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "tor-proto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c911edb20425cff696606795d80241d4c412293254bd88b8a7a84ed92c3a098"
+dependencies = [
+ "asynchronous-codec",
+ "bitvec",
+ "bytes",
+ "cipher",
+ "coarsetime",
+ "derive-deftly 0.14.6",
+ "derive_builder_fork_arti",
+ "derive_more 1.0.0",
+ "digest 0.10.7",
+ "educe 0.4.23",
+ "futures",
+ "hkdf",
+ "hmac",
+ "oneshot-fused-workaround",
+ "pin-project",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "safelog",
+ "subtle",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-cert",
+ "tor-checkable",
+ "tor-config",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-log-ratelim",
+ "tor-memquota",
+ "tor-rtcompat",
+ "tor-rtmock",
+ "tor-units",
+ "tracing",
+ "typenum",
+ "visibility",
+ "void",
+ "zeroize",
+]
+
+[[package]]
+name = "tor-protover"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc5e3793a53b21b0c98304ea42e1f0fcab3bb37eca96027f9cb4df90685ba31"
+dependencies = [
+ "caret",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "tor-relay-selection"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba71ca940e15bb86586c3e0cb98b94b9f63a816ef7e1df6aa59cde1114bf86f"
+dependencies = [
+ "rand 0.8.5",
+ "serde",
+ "tor-basic-utils",
+ "tor-linkspec",
+ "tor-netdir",
+ "tor-netdoc",
+]
+
+[[package]]
+name = "tor-rtcompat"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d91a0e023078fad1f6c65367efac78dada4c5c9ede7498ce7772f66f3bed15b"
+dependencies = [
+ "async-native-tls",
+ "async-trait",
+ "async_executors",
+ "coarsetime",
+ "derive_more 1.0.0",
+ "dyn-clone",
+ "educe 0.4.23",
+ "futures",
+ "native-tls",
+ "paste",
+ "pin-project",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util",
+ "tor-error",
+ "tor-general-addr",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "tor-rtmock"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc825722bcad1dca140540a166e582409b4408ce6fbefd8e08d45264ea99f2"
+dependencies = [
+ "amplify",
+ "async-trait",
+ "derive-deftly 0.14.6",
+ "derive_more 1.0.0",
+ "educe 0.4.23",
+ "futures",
+ "humantime",
+ "itertools 0.13.0",
+ "oneshot-fused-workaround",
+ "pin-project",
+ "priority-queue",
+ "slotmap-careful",
+ "strum 0.26.3",
+ "thiserror 1.0.69",
+ "tor-error",
+ "tor-general-addr",
+ "tor-rtcompat",
+ "tracing",
+ "tracing-test",
+ "void",
+]
+
+[[package]]
+name = "tor-socksproto"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eb7a8c792dd59b63fc25add39982d0509c3a58fe6e40eb2294324bf0d30f364"
+dependencies = [
+ "amplify",
+ "caret",
+ "derive-deftly 0.14.6",
+ "educe 0.4.23",
+ "safelog",
+ "subtle",
+ "thiserror 1.0.69",
+ "tor-bytes",
+ "tor-error",
+]
+
+[[package]]
+name = "tor-units"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01b1660c5ba8d5851d5411be3f9c0ae629e2b4e6e8db655b74f354611e5c18a7"
+dependencies = [
+ "derive-deftly 0.14.6",
+ "derive_more 1.0.0",
+ "thiserror 1.0.69",
+ "tor-memquota",
 ]
 
 [[package]]
@@ -5018,7 +7463,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http",
@@ -5092,12 +7537,37 @@ version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a4c448db514d4f24c5ddb9f73f2ee71bfb24c526cf0c570ba142d1119e0051"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
+dependencies = [
+ "quote",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -5105,6 +7575,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-index-collections"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183496e014253d15abbe6235677b1392dba2d40524c88938991226baa38ac7c4"
 
 [[package]]
 name = "typenum"
@@ -5137,6 +7613,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5162,6 +7647,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -5234,12 +7725,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -5271,6 +7789,15 @@ name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+
+[[package]]
+name = "wasix"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1757e0d1f8456693c7e5c6c629bdb54884e032aa0bb53c155f6a39f94440d332"
+dependencies = [
+ "wasi",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5345,6 +7872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weak-table"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
+
+[[package]]
 name = "web-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5382,6 +7915,37 @@ dependencies = [
  "libredox",
  "wasite",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -5695,6 +8259,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "xattr"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5705,6 +8281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+
+[[package]]
 name = "yaml-rust2"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5712,7 +8294,7 @@ checksum = "2462ea039c445496d8793d052e13787f2b90e750b833afee748e601c17621ed9"
 dependencies = [
  "arraydeque",
  "encoding_rs",
- "hashlink",
+ "hashlink 0.10.0",
 ]
 
 [[package]]
@@ -5868,4 +8450,32 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["evm", "indexing", "events", "ethereum"]
 [features]
 default = []
 test-utils = ["dep:fake"]
+tor = ["dep:arti-client", "dep:tor-cell", "dep:hyper", "dep:hyper-util", "dep:tower"]
 
 [dependencies]
 alloy = { version = "1.4.0", features = ["rpc-types", "json", "rpc-client", "json-rpc"] }
@@ -31,6 +32,13 @@ tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 config = { version = "0.15.19", default-features = false, features = ["yaml", "async"] }
 fake = { version = "4.4.0", optional = true }
+
+# Tor hidden-service support (enabled with --features tor)
+arti-client = { version = "0.24.0", features = ["tokio", "onion-service-service"], optional = true }
+tor-cell = { version = "0.24.0", optional = true }
+hyper = { version = "1.4.1", features = ["http1", "server"], optional = true }
+hyper-util = { version = "0.1.6", features = ["tokio"], optional = true }
+tower = { version = "0.5", features = ["util"], optional = true }
 
 [dependencies.sqlx]
 version = "0.8.6"

--- a/src/api_rest.rs
+++ b/src/api_rest.rs
@@ -310,14 +310,13 @@ async fn onion_cors_middleware(req: Request<axum::body::Body>, next: Next) -> Re
 
     let mut response = next.run(req).await;
 
-    if let Some(origin) = origin {
-        if origin.ends_with(".onion") || origin.ends_with(".onion/") {
-            if let Ok(val) = HeaderValue::from_str(&origin) {
-                response
-                    .headers_mut()
-                    .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, val);
-            }
-        }
+    if let Some(origin) = origin
+        && (origin.ends_with(".onion") || origin.ends_with(".onion/"))
+        && let Ok(val) = HeaderValue::from_str(&origin)
+    {
+        response
+            .headers_mut()
+            .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, val);
     }
 
     response

--- a/src/api_rest.rs
+++ b/src/api_rest.rs
@@ -6,6 +6,7 @@ use crate::{
     storage::{ContractDescriptorDb, EventDescriptorDb, StorageFactory},
 };
 use anyhow::Result;
+use axum::http::Request;
 use axum::{
     Router,
     extract::State,
@@ -14,7 +15,6 @@ use axum::{
     response::{Json, Response},
     routing::{get, post},
 };
-use axum::http::Request;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
@@ -289,10 +289,7 @@ async fn tor_info_handler(
 /// Applied to the router served over Tor so that clients cannot inadvertently
 /// leak browser fingerprint data (`User-Agent`, `Referer`) or network topology
 /// (`X-Forwarded-For`) through their request headers.
-pub async fn strip_identifying_headers(
-    mut req: Request<axum::body::Body>,
-    next: Next,
-) -> Response {
+pub async fn strip_identifying_headers(mut req: Request<axum::body::Body>, next: Next) -> Response {
     let headers = req.headers_mut();
     headers.remove(header::USER_AGENT);
     headers.remove(header::REFERER);
@@ -316,7 +313,9 @@ async fn onion_cors_middleware(req: Request<axum::body::Body>, next: Next) -> Re
     if let Some(origin) = origin {
         if origin.ends_with(".onion") || origin.ends_with(".onion/") {
             if let Ok(val) = HeaderValue::from_str(&origin) {
-                response.headers_mut().insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, val);
+                response
+                    .headers_mut()
+                    .insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, val);
             }
         }
     }

--- a/src/api_rest.rs
+++ b/src/api_rest.rs
@@ -73,7 +73,7 @@ pub struct TorInfoResponse {
 ///
 /// When Tor is disabled this is `None` and `/tor-info` returns `enabled: false`.
 #[cfg(feature = "tor")]
-pub type TorStateHandle = Option<Arc<crate::tor_service::TorState>>;
+pub type TorStateHandle = Option<crate::tor_service::TorState>;
 #[cfg(not(feature = "tor"))]
 pub type TorStateHandle = Option<()>;
 

--- a/src/api_rest.rs
+++ b/src/api_rest.rs
@@ -9,10 +9,12 @@ use anyhow::Result;
 use axum::{
     Router,
     extract::State,
-    http::StatusCode,
-    response::Json,
+    http::{HeaderValue, StatusCode, header},
+    middleware::{self, Next},
+    response::{Json, Response},
     routing::{get, post},
 };
+use axum::http::Request;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
@@ -53,15 +55,38 @@ pub struct DbSchemaResponse {
     pub schema: Value,
 }
 
+/// Response type for the /tor-info endpoint.
+#[derive(Serialize)]
+pub struct TorInfoResponse {
+    pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub onion_address: Option<String>,
+    pub bootstrapped: bool,
+    pub streams_accepted: u64,
+    /// Currently active circuits (rendezvous connections).
+    pub circuits_active: u64,
+    /// Total circuits rejected by the rate limiter since startup.
+    pub circuits_rejected: u64,
+}
+
+/// Shared Tor state injected into the router when `--tor` is active.
+///
+/// When Tor is disabled this is `None` and `/tor-info` returns `enabled: false`.
+#[cfg(feature = "tor")]
+pub type TorStateHandle = Option<Arc<crate::tor_service::TorState>>;
+#[cfg(not(feature = "tor"))]
+pub type TorStateHandle = Option<()>;
+
 /// GET handler for /list_events
 ///
 /// # Description
 ///
 /// This handler is used to list all the events indexed in the database along their indexing status.
-#[instrument(skip(factory))]
+#[instrument(skip(state))]
 async fn list_events_handler(
-    State(factory): State<Arc<dyn StorageFactory>>,
+    State(state): State<AppState>,
 ) -> Result<Json<ListEventsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let factory = &state.0;
     // Create a new storage instance with a new connection for this request
     let storage = factory.create_storage().map_err(|e| {
         error!("Failed to create database connection: {e}");
@@ -95,10 +120,11 @@ async fn list_events_handler(
 /// # Description
 ///
 /// This handler is used to list all the contracts indexed in the database.
-#[instrument(skip(factory))]
+#[instrument(skip(state))]
 async fn list_contracts_handler(
-    State(factory): State<Arc<dyn StorageFactory>>,
+    State(state): State<AppState>,
 ) -> Result<Json<ListContractsResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let factory = &state.0;
     // Create a new storage instance with a new connection for this request
     let storage = factory.create_storage().map_err(|e| {
         error!("Failed to create database connection: {e}");
@@ -132,11 +158,12 @@ async fn list_contracts_handler(
 /// # Description
 ///
 /// This handler is used to execute SQL queries against the indexer database. Only SELECT queries are supported.
-#[instrument(skip(factory, payload), fields(query = %payload.query))]
+#[instrument(skip(state, payload), fields(query = %payload.query))]
 async fn raw_query_handler(
-    State(factory): State<Arc<dyn StorageFactory>>,
+    State(state): State<AppState>,
     Json(payload): Json<RawQueryRequest>,
 ) -> Result<Json<RawQueryResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let factory = &state.0;
     // First, check if the query is a SELECT query.
     if !payload
         .query
@@ -191,10 +218,11 @@ async fn raw_query_handler(
 ///
 /// This handler returns the database schema including all tables (except quixote_info)
 /// and their column definitions.
-#[instrument(skip(factory))]
+#[instrument(skip(state))]
 async fn db_schema_handler(
-    State(factory): State<Arc<dyn StorageFactory>>,
+    State(state): State<AppState>,
 ) -> Result<Json<DbSchemaResponse>, (StatusCode, Json<ErrorResponse>)> {
+    let factory = &state.0;
     let storage = factory.create_storage().map_err(|e| {
         error!("Failed to create database connection: {e}");
         (
@@ -223,25 +251,105 @@ async fn db_schema_handler(
     }
 }
 
+/// GET handler for /tor-info
+///
+/// Returns metadata about the Tor hidden service: onion address, bootstrap status,
+/// and number of circuits (streams) accepted so far.  Always present regardless of
+/// whether Tor is enabled so callers can discover it without prior knowledge.
+async fn tor_info_handler(
+    State((_, tor_state)): State<(Arc<dyn StorageFactory>, TorStateHandle)>,
+) -> Json<TorInfoResponse> {
+    #[cfg(feature = "tor")]
+    if let Some(state) = &tor_state {
+        let info = state.info().await;
+        return Json(TorInfoResponse {
+            enabled: true,
+            onion_address: info.onion_address,
+            bootstrapped: info.bootstrapped,
+            streams_accepted: info.streams_accepted,
+            circuits_active: info.circuits_active,
+            circuits_rejected: info.circuits_rejected,
+        });
+    }
+
+    // Tor not enabled (either binary lacks the feature or --tor was not passed).
+    let _ = tor_state; // suppress unused-variable warning in non-tor builds
+    Json(TorInfoResponse {
+        enabled: false,
+        onion_address: None,
+        bootstrapped: false,
+        streams_accepted: 0,
+        circuits_active: 0,
+        circuits_rejected: 0,
+    })
+}
+
+/// Axum middleware that removes Tor-sensitive fingerprinting headers.
+///
+/// Applied to the router served over Tor so that clients cannot inadvertently
+/// leak browser fingerprint data (`User-Agent`, `Referer`) or network topology
+/// (`X-Forwarded-For`) through their request headers.
+pub async fn strip_identifying_headers(
+    mut req: Request<axum::body::Body>,
+    next: Next,
+) -> Response {
+    let headers = req.headers_mut();
+    headers.remove(header::USER_AGENT);
+    headers.remove(header::REFERER);
+    headers.remove("x-forwarded-for");
+    next.run(req).await
+}
+
+/// Axum middleware that adds `Access-Control-Allow-Origin` for `.onion` origins.
+///
+/// This allows browser clients running inside Tor Browser (whose origin is a
+/// `.onion` URL) to call the API without CORS errors.
+async fn onion_cors_middleware(req: Request<axum::body::Body>, next: Next) -> Response {
+    let origin = req
+        .headers()
+        .get(header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_owned());
+
+    let mut response = next.run(req).await;
+
+    if let Some(origin) = origin {
+        if origin.ends_with(".onion") || origin.ends_with(".onion/") {
+            if let Ok(val) = HeaderValue::from_str(&origin) {
+                response.headers_mut().insert(header::ACCESS_CONTROL_ALLOW_ORIGIN, val);
+            }
+        }
+    }
+
+    response
+}
+
+/// Combined state passed to every handler: storage factory + optional Tor state.
+type AppState = (Arc<dyn StorageFactory>, TorStateHandle);
+
 /// Creates and returns the REST API router
-pub fn create_router(factory: Arc<dyn StorageFactory>) -> Router {
+pub fn create_router(factory: Arc<dyn StorageFactory>, tor_state: TorStateHandle) -> Router {
+    let state: AppState = (factory, tor_state);
     Router::new()
         .route("/list_events", get(list_events_handler))
         .route("/list_contracts", get(list_contracts_handler))
         .route("/raw_query", post(raw_query_handler))
         .route("/db_schema", get(db_schema_handler))
-        .with_state(factory)
+        .route("/tor-info", get(tor_info_handler))
+        .layer(middleware::from_fn(onion_cors_middleware))
+        .with_state(state)
 }
 
 /// Starts the REST API server in a separate task
 pub async fn start_api_server(
     server_address: &str,
     storage_backend: Arc<dyn StorageFactory>,
+    tor_state: TorStateHandle,
     cancellation_token: CancellationToken,
 ) -> Result<()> {
     let server_address = server_address.to_string();
     tokio::spawn(async move {
-        let app = create_router(storage_backend);
+        let app = create_router(storage_backend, tor_state);
         let port = server_address.split(":").nth(1).unwrap().to_string();
 
         let listener = tokio::net::TcpListener::bind(server_address)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -115,4 +115,10 @@ pub struct IndexingArgs {
         help = "Optional Access-Control-Allow-Origin value for the metrics endpoint"
     )]
     pub metrics_allow_origin: Option<String>,
+    #[arg(
+        long,
+        help = "Enable Tor hidden service (.onion). Requires the binary to be compiled with --features tor.",
+        default_value_t = false
+    )]
+    pub tor: bool,
 }

--- a/src/collector_seed.rs
+++ b/src/collector_seed.rs
@@ -618,6 +618,7 @@ mod tests {
             metrics_address: "127.0.0.1".to_string(),
             metrics_port: 5054,
             metrics_allow_origin: None,
+            tor: false,
         }
     }
 
@@ -646,6 +647,7 @@ mod tests {
             metrics_address: "127.0.0.1".to_string(),
             metrics_port: 5054,
             metrics_allow_origin: None,
+            tor: false,
         }
     }
 
@@ -690,6 +692,7 @@ mod tests {
             metrics_address: "127.0.0.1".to_string(),
             metrics_port: 5054,
             metrics_allow_origin: None,
+            tor: false,
         }
     }
 
@@ -727,6 +730,7 @@ mod tests {
             metrics_address: "127.0.0.1".to_string(),
             metrics_port: 5054,
             metrics_allow_origin: None,
+            tor: false,
         }
     }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -113,6 +113,7 @@ pub struct IndexerConfiguration {
     pub metrics_address: String,
     pub metrics_port: u16,
     pub metrics_allow_origin: Option<String>,
+    pub tor: bool,
 }
 
 impl IndexerConfiguration {
@@ -201,6 +202,7 @@ impl IndexerConfiguration {
             metrics_address: args.metrics_address,
             metrics_port: args.metrics_port,
             metrics_allow_origin: args.metrics_allow_origin,
+            tor: args.tor,
         }
     }
 
@@ -324,6 +326,7 @@ mod tests {
             metrics_address: "127.0.0.1".to_string(),
             metrics_port: 5054,
             metrics_allow_origin: None,
+            tor: false,
         }
     }
 

--- a/src/event_collector.rs
+++ b/src/event_collector.rs
@@ -374,8 +374,8 @@ mod tests {
     ) {
         let (producer_buffer, mut consumer_buffer) = mpsc::channel(1000);
         let metrics = crate::metrics::MetricsHandle::default();
-        // A block range of 10 blocks is the safest choice to avoid throttling the RPC server.
-        seed_fixture.block_range = 10;
+        // A block range of 100 blocks is the safest choice to avoid throttling the RPC server.
+        seed_fixture.block_range = 100;
         let mut collector =
             EventCollector::new(provider_fixture, producer_buffer, &seed_fixture, metrics);
         collector.sync_mode = BlockNumberOrTag::Number(TARGET_BLOCK_SHORT_TEST);
@@ -412,10 +412,6 @@ mod tests {
         provider_fixture: Arc<dyn Provider + Send + Sync + 'static>,
         mut seed_fixture: CollectorSeed,
     ) {
-        // Wait for check_transfer_events_for_a_block_range to complete first to avoid
-        // rate limiting interference between the two tests.
-        sleep(Duration::from_secs(25)).await;
-
         let (producer_buffer, mut consumer_buffer) = mpsc::channel(1000);
         let metrics = crate::metrics::MetricsHandle::default();
         // 10k throttles the RPC at the second request.

--- a/src/event_collector.rs
+++ b/src/event_collector.rs
@@ -412,6 +412,10 @@ mod tests {
         provider_fixture: Arc<dyn Provider + Send + Sync + 'static>,
         mut seed_fixture: CollectorSeed,
     ) {
+        // Wait for check_transfer_events_for_a_block_range to complete first to avoid
+        // rate limiting interference between the two tests.
+        sleep(Duration::from_secs(25)).await;
+
         let (producer_buffer, mut consumer_buffer) = mpsc::channel(1000);
         let metrics = crate::metrics::MetricsHandle::default();
         // 10k throttles the RPC at the second request.

--- a/src/indexing_app.rs
+++ b/src/indexing_app.rs
@@ -4,7 +4,7 @@
 use crate::{
     CancellationToken, CollectorSeed, EventCollectorRunner, EventProcessor, OptionalAddressDisplay,
     TxLogChunk,
-    api_rest::start_api_server,
+    api_rest::{TorStateHandle, start_api_server},
     configuration::{DatabaseBackend, IndexerConfiguration},
     constants, error_codes,
     metrics::{MetricsConfig, MetricsHandle},
@@ -26,6 +26,7 @@ pub struct IndexingApp {
     pub seeds: Vec<CollectorSeed>,
     pub metrics_config: MetricsConfig,
     pub metrics: MetricsHandle,
+    pub tor_enabled: bool,
 }
 
 impl IndexingApp {
@@ -84,6 +85,7 @@ impl IndexingApp {
             seeds,
             metrics_config,
             metrics,
+            tor_enabled: config.tor,
         })
     }
 
@@ -144,10 +146,15 @@ impl IndexingApp {
         let event_collector_runner =
             EventCollectorRunner::new(self.seeds.clone(), seed_buffers, self.metrics.clone())?;
 
+        // Optionally start the Tor hidden service.
+        // The returned TorState is shared with the REST API for /tor-info.
+        let tor_state: TorStateHandle = self.start_tor_if_enabled().await;
+
         // Start the REST API server
         start_api_server(
             self.api_server_address.as_str(),
             self.storage_for_api.clone(),
+            tor_state,
             self.cancellation_token.clone(),
         )
         .await
@@ -173,6 +180,44 @@ impl IndexingApp {
         info!("Shutdown complete");
 
         Ok(())
+    }
+
+    /// Start the Tor onion service if `--tor` was passed and the binary was built
+    /// with `--features tor`.  Returns a `TorState` handle on success, `None` otherwise.
+    async fn start_tor_if_enabled(&self) -> TorStateHandle {
+        if !self.tor_enabled {
+            return None;
+        }
+
+        #[cfg(feature = "tor")]
+        {
+            use crate::{
+                api_rest::{create_router, strip_identifying_headers},
+                tor_service::start_tor_service,
+            };
+            use axum::middleware;
+            let router = create_router(self.storage_for_api.clone(), None)
+                .layer(middleware::from_fn(strip_identifying_headers));
+            match start_tor_service(router, self.cancellation_token.clone()).await {
+                Ok(state) => {
+                    info!("Tor hidden service started");
+                    return Some(std::sync::Arc::new(state));
+                }
+                Err(e) => {
+                    error!("Failed to start Tor service: {e:#}");
+                }
+            }
+        }
+
+        #[cfg(not(feature = "tor"))]
+        {
+            warn!(
+                "--tor flag was passed but this binary was not compiled with --features tor. \
+                 Rebuild with `cargo build --features tor` to enable the hidden service."
+            );
+        }
+
+        None
     }
 
     fn spawn_kill_handler(cancellation_token: CancellationToken) -> tokio::task::JoinHandle<()> {

--- a/src/indexing_app.rs
+++ b/src/indexing_app.rs
@@ -193,15 +193,16 @@ impl IndexingApp {
         {
             use crate::{
                 api_rest::{create_router, strip_identifying_headers},
-                tor_service::start_tor_service,
+                tor_service::{TorState, start_tor_service},
             };
             use axum::middleware;
-            let router = create_router(self.storage_for_api.clone(), None)
+            let state = TorState::new();
+            let router = create_router(self.storage_for_api.clone(), Some(state.clone()))
                 .layer(middleware::from_fn(strip_identifying_headers));
-            match start_tor_service(router, self.cancellation_token.clone()).await {
-                Ok(state) => {
+            match start_tor_service(router, self.cancellation_token.clone(), state.clone()).await {
+                Ok(()) => {
                     info!("Tor hidden service started");
-                    return Some(std::sync::Arc::new(state));
+                    return Some(state);
                 }
                 Err(e) => {
                     error!("Failed to start Tor service: {e:#}");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@ pub mod metrics;
 pub mod streamlit_wrapper;
 pub use configuration::IndexerConfiguration;
 pub mod telemetry;
+#[cfg(feature = "tor")]
+pub mod tor_service;
 
 /// Module with constants used throughout the application.
 pub mod constants {

--- a/src/storage/storage_duckdb.rs
+++ b/src/storage/storage_duckdb.rs
@@ -648,7 +648,7 @@ impl DuckDBStorage {
                 .map(|r| r.unwrap())
                 .collect::<Vec<String>>();
 
-            contracts.extend(addresses.into_iter());
+            contracts.extend(addresses);
         }
 
         Ok(contracts

--- a/src/tor_service.rs
+++ b/src/tor_service.rs
@@ -15,8 +15,9 @@ pub use imp::*;
 mod imp {
     use crate::CancellationToken;
     use anyhow::{Context, Result};
-    use arti_client::{TorClient, TorClientConfig, config::onion_service::OnionServiceConfigBuilder};
-    use tokio::time::{Duration, timeout};
+    use arti_client::{
+        TorClient, TorClientConfig, config::onion_service::OnionServiceConfigBuilder,
+    };
     use axum::Router;
     use axum::body::Body;
     use futures::StreamExt;
@@ -28,6 +29,7 @@ mod imp {
         atomic::{AtomicBool, AtomicU64, Ordering},
     };
     use tokio::sync::RwLock;
+    use tokio::time::{Duration, timeout};
     use tor_cell::relaycell::msg::Connected;
     use tower::ServiceExt;
     use tracing::{error, info, warn};

--- a/src/tor_service.rs
+++ b/src/tor_service.rs
@@ -63,6 +63,12 @@ mod imp {
         circuits_rejected: AtomicU64,
     }
 
+    impl Default for TorState {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     impl TorState {
         pub fn new() -> Self {
             Self {

--- a/src/tor_service.rs
+++ b/src/tor_service.rs
@@ -186,22 +186,21 @@ mod imp {
 
     /// Start the Tor hidden service and serve `router` over it.
     ///
-    /// Returns a `TorState` handle that is shared with the REST API for the
-    /// `/tor-info` endpoint.  Shuts down gracefully when `cancellation_token` fires.
+    /// `state` must be the same `TorState` that was injected into `router` via
+    /// `create_router` so that `/tor-info` reflects live Tor metrics.
+    /// Shuts down gracefully when `cancellation_token` fires.
     pub async fn start_tor_service(
         router: Router,
         cancellation_token: CancellationToken,
-    ) -> Result<TorState> {
-        let state = TorState::new();
-        let state_clone = state.clone();
-
+        state: TorState,
+    ) -> Result<()> {
         tokio::spawn(async move {
-            if let Err(e) = run_tor_service(router, cancellation_token, state_clone).await {
+            if let Err(e) = run_tor_service(router, cancellation_token, state).await {
                 error!("Tor service terminated with error: {e:#}");
             }
         });
 
-        Ok(state)
+        Ok(())
     }
 
     async fn run_tor_service(

--- a/src/tor_service.rs
+++ b/src/tor_service.rs
@@ -1,0 +1,349 @@
+// Copyright (c) 2026 Bilinear Labs
+// SPDX-License-Identifier: MIT
+
+//! Tor hidden-service lifecycle management.
+//!
+//! Bootstraps an arti Tor client, launches a `.onion` service, and serves the
+//! existing Axum router over it using raw hyper HTTP/1.1 connections.
+//!
+//! Enabled only when the crate is compiled with `--features tor`.
+
+#[cfg(feature = "tor")]
+pub use imp::*;
+
+#[cfg(feature = "tor")]
+mod imp {
+    use crate::CancellationToken;
+    use anyhow::{Context, Result};
+    use arti_client::{TorClient, TorClientConfig, config::onion_service::OnionServiceConfigBuilder};
+    use tokio::time::{Duration, timeout};
+    use axum::Router;
+    use axum::body::Body;
+    use futures::StreamExt;
+    use hyper::body::Incoming;
+    use hyper_util::rt::TokioIo;
+    use serde::Serialize;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    };
+    use tokio::sync::RwLock;
+    use tor_cell::relaycell::msg::Connected;
+    use tower::ServiceExt;
+    use tracing::{error, info, warn};
+
+    /// Privacy-relevant metadata exposed by the `/tor-info` endpoint.
+    #[derive(Clone, Serialize)]
+    pub struct TorInfo {
+        /// The `.onion` address (v3, 56-char base32 + `.onion`).
+        pub onion_address: Option<String>,
+        /// Whether the Tor client finished bootstrapping.
+        pub bootstrapped: bool,
+        /// Total streams accepted since startup.
+        pub streams_accepted: u64,
+        /// Currently active circuits (rendezvous connections).
+        pub circuits_active: u64,
+        /// Total circuits rejected by the rate limiter since startup.
+        pub circuits_rejected: u64,
+    }
+
+    /// Shared state updated by the Tor service task, readable via `/tor-info`.
+    #[derive(Clone)]
+    pub struct TorState {
+        inner: Arc<TorStateInner>,
+    }
+
+    struct TorStateInner {
+        onion_address: RwLock<Option<String>>,
+        bootstrapped: AtomicBool,
+        streams_accepted: AtomicU64,
+        circuits_active: AtomicU64,
+        circuits_rejected: AtomicU64,
+    }
+
+    impl TorState {
+        pub fn new() -> Self {
+            Self {
+                inner: Arc::new(TorStateInner {
+                    onion_address: RwLock::new(None),
+                    bootstrapped: AtomicBool::new(false),
+                    streams_accepted: AtomicU64::new(0),
+                    circuits_active: AtomicU64::new(0),
+                    circuits_rejected: AtomicU64::new(0),
+                }),
+            }
+        }
+
+        async fn set_onion_address(&self, addr: String) {
+            *self.inner.onion_address.write().await = Some(addr);
+        }
+
+        fn set_bootstrapped(&self) {
+            self.inner.bootstrapped.store(true, Ordering::Relaxed);
+        }
+
+        fn increment_streams(&self) {
+            self.inner.streams_accepted.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn increment_circuits_active(&self) {
+            self.inner.circuits_active.fetch_add(1, Ordering::Relaxed);
+        }
+
+        fn decrement_circuits_active(&self) {
+            self.inner.circuits_active.fetch_sub(1, Ordering::Relaxed);
+        }
+
+        fn increment_circuits_rejected(&self) {
+            self.inner.circuits_rejected.fetch_add(1, Ordering::Relaxed);
+        }
+
+        pub async fn info(&self) -> TorInfo {
+            TorInfo {
+                onion_address: self.inner.onion_address.read().await.clone(),
+                bootstrapped: self.inner.bootstrapped.load(Ordering::Relaxed),
+                streams_accepted: self.inner.streams_accepted.load(Ordering::Relaxed),
+                circuits_active: self.inner.circuits_active.load(Ordering::Relaxed),
+                circuits_rejected: self.inner.circuits_rejected.load(Ordering::Relaxed),
+            }
+        }
+    }
+
+    // ── Circuit-aware rate limiting ───────────────────────────────────────────
+
+    /// Limits new circuit (rendezvous) connections to the hidden service.
+    ///
+    /// Two independent limits are enforced:
+    /// - `max_concurrent`: hard cap on simultaneously active circuits.
+    /// - `window_max` per `window_duration`: rate cap on new circuit creation.
+    ///
+    /// Both are enforced at the circuit level — the only meaningful identity
+    /// available to a Tor hidden service, since client IPs are not visible.
+    struct CircuitLimiter {
+        max_concurrent: u64,
+        active: AtomicU64,
+        window_max: u64,
+        window_duration: Duration,
+        // Guarded by a std mutex; the lock is never held across an await point.
+        window_start: std::sync::Mutex<std::time::Instant>,
+        window_count: AtomicU64,
+    }
+
+    impl CircuitLimiter {
+        fn new(max_concurrent: u64, window_max: u64, window_duration: Duration) -> Arc<Self> {
+            Arc::new(Self {
+                max_concurrent,
+                active: AtomicU64::new(0),
+                window_max,
+                window_duration,
+                window_start: std::sync::Mutex::new(std::time::Instant::now()),
+                window_count: AtomicU64::new(0),
+            })
+        }
+
+        /// Returns `true` and records the circuit if both limits allow it.
+        fn try_acquire(&self) -> bool {
+            if self.active.load(Ordering::Relaxed) >= self.max_concurrent {
+                return false;
+            }
+
+            let now = std::time::Instant::now();
+            let mut ws = self.window_start.lock().unwrap();
+            if now.duration_since(*ws) >= self.window_duration {
+                *ws = now;
+                self.window_count.store(1, Ordering::Relaxed);
+            } else {
+                let prev = self.window_count.fetch_add(1, Ordering::Relaxed);
+                if prev >= self.window_max {
+                    return false;
+                }
+            }
+
+            self.active.fetch_add(1, Ordering::Relaxed);
+            true
+        }
+
+        fn release(&self) {
+            self.active.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
+
+    /// RAII guard that releases the `CircuitLimiter` slot and decrements the
+    /// active-circuit counter when a circuit task exits, even on panic.
+    struct CircuitGuard {
+        limiter: Arc<CircuitLimiter>,
+        state: TorState,
+    }
+
+    impl Drop for CircuitGuard {
+        fn drop(&mut self) {
+            self.limiter.release();
+            self.state.decrement_circuits_active();
+        }
+    }
+
+    // ── Public entry point ────────────────────────────────────────────────────
+
+    /// Start the Tor hidden service and serve `router` over it.
+    ///
+    /// Returns a `TorState` handle that is shared with the REST API for the
+    /// `/tor-info` endpoint.  Shuts down gracefully when `cancellation_token` fires.
+    pub async fn start_tor_service(
+        router: Router,
+        cancellation_token: CancellationToken,
+    ) -> Result<TorState> {
+        let state = TorState::new();
+        let state_clone = state.clone();
+
+        tokio::spawn(async move {
+            if let Err(e) = run_tor_service(router, cancellation_token, state_clone).await {
+                error!("Tor service terminated with error: {e:#}");
+            }
+        });
+
+        Ok(state)
+    }
+
+    async fn run_tor_service(
+        router: Router,
+        cancellation_token: CancellationToken,
+        state: TorState,
+    ) -> Result<()> {
+        info!("Bootstrapping Tor client…");
+
+        let tor_client = timeout(
+            Duration::from_secs(120),
+            TorClient::create_bootstrapped(TorClientConfig::default()),
+        )
+        .await
+        .context("Tor bootstrap timed out after 120 s — check network/firewall")?
+        .context("Failed to bootstrap Tor client")?;
+
+        state.set_bootstrapped();
+        info!("Tor client bootstrapped");
+
+        let nickname = "quixote"
+            .to_owned()
+            .try_into()
+            .context("Invalid onion service nickname")?;
+
+        let config = OnionServiceConfigBuilder::default()
+            .nickname(nickname)
+            .build()
+            .context("Failed to build onion service config")?;
+
+        let (onion_service, mut rend_requests) = tor_client
+            .launch_onion_service(config)
+            .context("Failed to launch onion service")?;
+
+        // The onion address is known immediately after launch (derived from the key).
+        if let Some(name) = onion_service.onion_name() {
+            let addr = name.to_string();
+            state.set_onion_address(addr.clone()).await;
+            info!("Tor onion service listening at http://{addr}");
+        }
+
+        // 64 concurrent circuits; at most 30 new circuits per 60-second window.
+        let limiter = CircuitLimiter::new(64, 30, Duration::from_secs(60));
+
+        let mut shutdown_rx = cancellation_token.subscribe();
+
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.recv() => {
+                    warn!("Tor service shutting down");
+                    break;
+                }
+                rend_req = rend_requests.next() => {
+                    let Some(rend_req) = rend_req else {
+                        warn!("Tor rendezvous stream ended");
+                        break;
+                    };
+
+                    if !limiter.try_acquire() {
+                        state.increment_circuits_rejected();
+                        warn!(
+                            circuits_active = limiter.active.load(Ordering::Relaxed),
+                            circuits_rejected = state.inner.circuits_rejected.load(Ordering::Relaxed),
+                            "Tor circuit rate-limited — dropping circuit"
+                        );
+                        // Dropping rend_req without accepting signals rejection to the client.
+                        continue;
+                    }
+                    state.increment_circuits_active();
+
+                    // Guard ensures limiter slot + active counter are released
+                    // when the circuit task exits, regardless of how it exits.
+                    let guard = CircuitGuard { limiter: limiter.clone(), state: state.clone() };
+
+                    // Each RendRequest represents one client connecting to the
+                    // onion service.  Accepting it yields a stream of individual
+                    // TCP-like streams (StreamRequests) over the circuit.
+                    let mut incoming = match rend_req.accept().await {
+                        Ok(s) => s,
+                        Err(e) => {
+                            warn!("Failed to accept rendezvous request: {e}");
+                            drop(guard);
+                            continue;
+                        }
+                    };
+
+                    let router = router.clone();
+                    let state = state.clone();
+
+                    tokio::spawn(async move {
+                        let _guard = guard;
+                        while let Some(stream_req) = incoming.next().await {
+                            // Accept only RELAY_BEGIN (new TCP stream) requests;
+                            // others (e.g. RELAY_BEGIN_DIR) are intentionally ignored.
+                            let data_stream = match stream_req.accept(Connected::new_empty()).await {
+                                Ok(ds) => ds,
+                                Err(e) => {
+                                    warn!("Failed to accept data stream: {e}");
+                                    continue;
+                                }
+                            };
+
+                            state.increment_streams();
+                            let router = router.clone();
+
+                            tokio::spawn(async move {
+                                serve_http(data_stream, router).await;
+                            });
+                        }
+                    });
+                }
+            }
+        }
+
+        // Dropping the OnionService tells arti to stop publishing the descriptor.
+        drop(onion_service);
+        Ok(())
+    }
+
+    /// Serve a single HTTP/1.1 connection over a Tor `DataStream`.
+    async fn serve_http(stream: arti_client::DataStream, router: Router) {
+        let io = TokioIo::new(stream);
+
+        // Wrap the axum Router in a hyper service_fn.
+        // We need to map the body type: hyper gives us `Incoming`, axum expects `Body`.
+        let svc = hyper::service::service_fn(move |req: hyper::Request<Incoming>| {
+            let router = router.clone();
+            async move {
+                let (parts, body) = req.into_parts();
+                let axum_req = hyper::Request::from_parts(parts, Body::new(body));
+                // ServiceExt::oneshot handles poll_ready + call.
+                // axum Router's error type is Infallible, which hyper accepts.
+                router.oneshot(axum_req).await
+            }
+        });
+
+        if let Err(e) = hyper::server::conn::http1::Builder::new()
+            .serve_connection(io, svc)
+            .await
+        {
+            // Connection reset / closed cleanly is expected; log at debug only.
+            tracing::debug!("Tor HTTP connection ended: {e}");
+        }
+    }
+}

--- a/tests/tor_integration.rs
+++ b/tests/tor_integration.rs
@@ -24,35 +24,57 @@ use tower::ServiceExt; // for Router::oneshot
 /// A minimal in-memory storage factory that satisfies the type constraint
 /// without needing a real database.
 mod stub_storage {
+    use alloy::json_abi::Event;
+    use alloy::{primitives::B256, rpc::types::Log};
     use anyhow::Result;
     use async_trait::async_trait;
     use quixote::{
         EventStatus,
-        storage::{
-            ContractDescriptorDb, EventDescriptorDb, Storage, StorageFactory,
-        },
+        storage::{ContractDescriptorDb, EventDescriptorDb, Storage, StorageFactory},
     };
     use serde_json::Value;
-    use alloy::{primitives::B256, rpc::types::Log};
-    use alloy::json_abi::Event;
 
     #[derive(Default)]
     pub struct Stub;
 
     #[async_trait]
     impl Storage for Stub {
-        async fn add_events(&self, _: u64, _: &[Log]) -> Result<()> { Ok(()) }
-        async fn list_indexed_events(&self) -> Result<Vec<EventDescriptorDb>> { Ok(vec![]) }
-        async fn event_index_status(&self, _: u64, _: &Event) -> Result<Option<EventStatus>> { Ok(None) }
-        async fn include_events(&self, _: u64, _: &[Event]) -> Result<()> { Ok(()) }
-        async fn get_event_signature(&self, _: &str) -> Result<String> { Ok(String::new()) }
-        async fn last_block(&self, _: u64, _: &Event) -> Result<u64> { Ok(0) }
-        async fn first_block(&self, _: u64, _: &Event) -> Result<u64> { Ok(0) }
-        async fn set_first_block(&self, _: u64, _: &Event, _: u64) -> Result<()> { Ok(()) }
-        async fn synchronize_events(&self, _: u64, _: &[B256], _: Option<u64>) -> Result<()> { Ok(()) }
-        async fn send_raw_query(&self, _: &str) -> Result<Value> { Ok(Value::Null) }
-        async fn list_contracts(&self) -> Result<Vec<ContractDescriptorDb>> { Ok(vec![]) }
-        async fn describe_database(&self) -> Result<Value> { Ok(Value::Null) }
+        async fn add_events(&self, _: u64, _: &[Log]) -> Result<()> {
+            Ok(())
+        }
+        async fn list_indexed_events(&self) -> Result<Vec<EventDescriptorDb>> {
+            Ok(vec![])
+        }
+        async fn event_index_status(&self, _: u64, _: &Event) -> Result<Option<EventStatus>> {
+            Ok(None)
+        }
+        async fn include_events(&self, _: u64, _: &[Event]) -> Result<()> {
+            Ok(())
+        }
+        async fn get_event_signature(&self, _: &str) -> Result<String> {
+            Ok(String::new())
+        }
+        async fn last_block(&self, _: u64, _: &Event) -> Result<u64> {
+            Ok(0)
+        }
+        async fn first_block(&self, _: u64, _: &Event) -> Result<u64> {
+            Ok(0)
+        }
+        async fn set_first_block(&self, _: u64, _: &Event, _: u64) -> Result<()> {
+            Ok(())
+        }
+        async fn synchronize_events(&self, _: u64, _: &[B256], _: Option<u64>) -> Result<()> {
+            Ok(())
+        }
+        async fn send_raw_query(&self, _: &str) -> Result<Value> {
+            Ok(Value::Null)
+        }
+        async fn list_contracts(&self) -> Result<Vec<ContractDescriptorDb>> {
+            Ok(vec![])
+        }
+        async fn describe_database(&self) -> Result<Value> {
+            Ok(Value::Null)
+        }
     }
 
     impl StorageFactory for Stub {
@@ -63,8 +85,7 @@ mod stub_storage {
 }
 
 fn make_router(tor_state: quixote::api_rest::TorStateHandle) -> axum::Router {
-    let factory: Arc<dyn quixote::storage::StorageFactory> =
-        Arc::new(stub_storage::Stub);
+    let factory: Arc<dyn quixote::storage::StorageFactory> = Arc::new(stub_storage::Stub);
     create_router(factory, tor_state)
 }
 
@@ -142,7 +163,11 @@ async fn cors_header_added_for_onion_origin() {
         .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
         .and_then(|v| v.to_str().ok());
 
-    assert_eq!(acao, Some(onion_origin), "ACAO header must echo the .onion origin");
+    assert_eq!(
+        acao,
+        Some(onion_origin),
+        "ACAO header must echo the .onion origin"
+    );
 }
 
 #[tokio::test]
@@ -157,11 +182,12 @@ async fn cors_header_not_added_for_regular_origin() {
 
     let response = router.oneshot(req).await.unwrap();
 
-    let acao = response
-        .headers()
-        .get(header::ACCESS_CONTROL_ALLOW_ORIGIN);
+    let acao = response.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN);
 
-    assert!(acao.is_none(), "ACAO header must NOT be set for non-.onion origins");
+    assert!(
+        acao.is_none(),
+        "ACAO header must NOT be set for non-.onion origins"
+    );
 }
 
 // ── Privacy-conscious logging / header stripping ──────────────────────────────

--- a/tests/tor_integration.rs
+++ b/tests/tor_integration.rs
@@ -104,8 +104,7 @@ async fn tor_info_returns_enabled_with_tor_state() {
     // Create a TorState without connecting to the Tor network —
     // we only need the shared handle to verify /tor-info returns enabled: true.
     let state = TorState::new();
-    let state_arc = Arc::new(state);
-    let router = make_router(Some(state_arc));
+    let router = make_router(Some(state));
 
     let req = Request::builder()
         .uri("/tor-info")
@@ -213,7 +212,7 @@ async fn privacy_middleware_strips_identifying_headers() {
 async fn tor_info_includes_circuit_stats() {
     use quixote::tor_service::TorState;
 
-    let state = Arc::new(TorState::new());
+    let state = TorState::new();
     let router = make_router(Some(state));
 
     let req = Request::builder()

--- a/tests/tor_integration.rs
+++ b/tests/tor_integration.rs
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 Bilinear Labs
+// SPDX-License-Identifier: MIT
+//
+//! Integration tests for the Tor hidden-service layer.
+//!
+//! These tests cover:
+//! 1. `/tor-info` returns `enabled: false` when Tor is not active.
+//! 2. `/tor-info` returns `enabled: true` and a valid onion address
+//!    when the binary is compiled with `--features tor` and Tor is active.
+//! 3. CORS headers are added for `.onion` origins but not for regular ones.
+//! 4. Privacy middleware strips `User-Agent`, `Referer`, and `X-Forwarded-For`.
+//! 5. `/tor-info` includes `circuits_active` and `circuits_rejected` counters.
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode, header},
+};
+use quixote::api_rest::create_router;
+use std::sync::Arc;
+use tower::ServiceExt; // for Router::oneshot
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// A minimal in-memory storage factory that satisfies the type constraint
+/// without needing a real database.
+mod stub_storage {
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use quixote::{
+        EventStatus,
+        storage::{
+            ContractDescriptorDb, EventDescriptorDb, Storage, StorageFactory,
+        },
+    };
+    use serde_json::Value;
+    use alloy::{primitives::B256, rpc::types::Log};
+    use alloy::json_abi::Event;
+
+    #[derive(Default)]
+    pub struct Stub;
+
+    #[async_trait]
+    impl Storage for Stub {
+        async fn add_events(&self, _: u64, _: &[Log]) -> Result<()> { Ok(()) }
+        async fn list_indexed_events(&self) -> Result<Vec<EventDescriptorDb>> { Ok(vec![]) }
+        async fn event_index_status(&self, _: u64, _: &Event) -> Result<Option<EventStatus>> { Ok(None) }
+        async fn include_events(&self, _: u64, _: &[Event]) -> Result<()> { Ok(()) }
+        async fn get_event_signature(&self, _: &str) -> Result<String> { Ok(String::new()) }
+        async fn last_block(&self, _: u64, _: &Event) -> Result<u64> { Ok(0) }
+        async fn first_block(&self, _: u64, _: &Event) -> Result<u64> { Ok(0) }
+        async fn set_first_block(&self, _: u64, _: &Event, _: u64) -> Result<()> { Ok(()) }
+        async fn synchronize_events(&self, _: u64, _: &[B256], _: Option<u64>) -> Result<()> { Ok(()) }
+        async fn send_raw_query(&self, _: &str) -> Result<Value> { Ok(Value::Null) }
+        async fn list_contracts(&self) -> Result<Vec<ContractDescriptorDb>> { Ok(vec![]) }
+        async fn describe_database(&self) -> Result<Value> { Ok(Value::Null) }
+    }
+
+    impl StorageFactory for Stub {
+        fn create_storage(&self) -> Result<Box<dyn Storage>> {
+            Ok(Box::new(Stub))
+        }
+    }
+}
+
+fn make_router(tor_state: quixote::api_rest::TorStateHandle) -> axum::Router {
+    let factory: Arc<dyn quixote::storage::StorageFactory> =
+        Arc::new(stub_storage::Stub);
+    create_router(factory, tor_state)
+}
+
+// ── /tor-info without Tor ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn tor_info_returns_disabled_when_tor_not_active() {
+    let router = make_router(None);
+
+    let req = Request::builder()
+        .uri("/tor-info")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["enabled"], false);
+    assert_eq!(json["bootstrapped"], false);
+    assert_eq!(json["streams_accepted"], 0);
+    assert_eq!(json["circuits_active"], 0);
+    assert_eq!(json["circuits_rejected"], 0);
+}
+
+// ── /tor-info with Tor feature compiled in ───────────────────────────────────
+
+#[cfg(feature = "tor")]
+#[tokio::test]
+async fn tor_info_returns_enabled_with_tor_state() {
+    use quixote::tor_service::TorState;
+
+    // Create a TorState without connecting to the Tor network —
+    // we only need the shared handle to verify /tor-info returns enabled: true.
+    let state = TorState::new();
+    let state_arc = Arc::new(state);
+    let router = make_router(Some(state_arc));
+
+    let req = Request::builder()
+        .uri("/tor-info")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["enabled"], true);
+}
+
+// ── CORS middleware ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn cors_header_added_for_onion_origin() {
+    let router = make_router(None);
+
+    let onion_origin = "http://exampleonionaddress56chars1234567890abcdef.onion";
+    let req = Request::builder()
+        .uri("/tor-info")
+        .header(header::ORIGIN, onion_origin)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(req).await.unwrap();
+
+    let acao = response
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .and_then(|v| v.to_str().ok());
+
+    assert_eq!(acao, Some(onion_origin), "ACAO header must echo the .onion origin");
+}
+
+#[tokio::test]
+async fn cors_header_not_added_for_regular_origin() {
+    let router = make_router(None);
+
+    let req = Request::builder()
+        .uri("/tor-info")
+        .header(header::ORIGIN, "https://example.com")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(req).await.unwrap();
+
+    let acao = response
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_ORIGIN);
+
+    assert!(acao.is_none(), "ACAO header must NOT be set for non-.onion origins");
+}
+
+// ── Privacy-conscious logging / header stripping ──────────────────────────────
+
+#[tokio::test]
+async fn privacy_middleware_strips_identifying_headers() {
+    use axum::{Router, middleware, routing::get};
+    use quixote::api_rest::strip_identifying_headers;
+
+    // Minimal router that echoes whether each sensitive header is present.
+    let test_router = Router::new()
+        .route(
+            "/check",
+            get(|req: axum::extract::Request| async move {
+                let h = req.headers();
+                let has_ua = h.contains_key(header::USER_AGENT);
+                let has_ref = h.contains_key(header::REFERER);
+                let has_xff = h.contains_key("x-forwarded-for");
+                format!("{has_ua},{has_ref},{has_xff}")
+            }),
+        )
+        .layer(middleware::from_fn(strip_identifying_headers));
+
+    let req = Request::builder()
+        .uri("/check")
+        .header(header::USER_AGENT, "Mozilla/5.0 TorBrowser/14.0")
+        .header(header::REFERER, "https://example.com/page")
+        .header("x-forwarded-for", "203.0.113.1")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = test_router.oneshot(req).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        &body[..],
+        b"false,false,false",
+        "User-Agent, Referer, and X-Forwarded-For must be stripped before the handler sees them"
+    );
+}
+
+// ── Circuit stats in /tor-info ────────────────────────────────────────────────
+
+#[cfg(feature = "tor")]
+#[tokio::test]
+async fn tor_info_includes_circuit_stats() {
+    use quixote::tor_service::TorState;
+
+    let state = Arc::new(TorState::new());
+    let router = make_router(Some(state));
+
+    let req = Request::builder()
+        .uri("/tor-info")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = router.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["enabled"], true);
+    assert_eq!(json["circuits_active"], 0);
+    assert_eq!(json["circuits_rejected"], 0);
+}


### PR DESCRIPTION
# Native Tor Integration

Adds an optional Tor hidden service backed by the `arti` Rust Tor client.

## How to enable

```sh
cargo build --features tor
quixote --tor
```

## New endpoint: `GET /tor-info`

Returns the onion address, bootstrap status, and circuit counters. Always present — returns `enabled: false` when Tor is off.

## Rate limiting

64 max concurrent circuits, 30 new circuits per 60-second window. Enforced at the circuit level since client IPs are not visible over Tor.

## Privacy middleware (Tor router only)

- Strips `User-Agent`, `Referer`, and `X-Forwarded-For` from incoming requests.
- Adds `Access-Control-Allow-Origin` only for `.onion` origins.
